### PR TITLE
fix(pat-3987): create dist directory when no -o

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
 use semver::Version;
-use std::fs::{create_dir, File};
+use std::fs::{create_dir_all, File};
 use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -153,9 +153,7 @@ impl App {
                     .get_package_version(package_identifier[0], version)
                     .await
                     .expect("error creating new package version");
-                if out_dir == Path::new("dist") {
-                    create_dir(&out_dir).expect("error creating dist directory");
-                }
+                create_dir_all(&out_dir).expect("error creating output directory");
                 check_output_dir(&out_dir);
                 generate_package(&package, &target, &out_dir, assume_yes);
             }

--- a/src/command.rs
+++ b/src/command.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
 use semver::Version;
-use std::fs::File;
+use std::fs::{create_dir, File};
 use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
 
@@ -153,6 +153,9 @@ impl App {
                     .get_package_version(package_identifier[0], version)
                     .await
                     .expect("error creating new package version");
+                if out_dir == Path::new("dist") {
+                    create_dir(&out_dir).expect("error creating dist directory");
+                }
                 check_output_dir(&out_dir);
                 generate_package(&package, &target, &out_dir, assume_yes);
             }


### PR DESCRIPTION
Checks whether the directory `out_dir` is the default `dist`. If so, create the default directory to put packages in.

Test plan:
- ran `cargo run build-package --package-identifier test-package@0.1.0 python` and checked contents in dist directory