### PR TITLE
fix(pat-3906): increase max message decoding size to 32MB

### DIFF
--- a/src/command/snowflake.rs
+++ b/src/command/snowflake.rs
@@ -31,6 +31,11 @@ use dpm_agent::{
 /// per https://stackoverflow.com/questions/13378815/base64-length-calculation.
 const MAX_BINARY_STRING_SIZE: i64 = 11_184_812;
 
+/// The maximum size of message decoded by the gRPC client.
+/// Defaults to 4MB, but we set it to 32MB.
+/// See https://docs.rs/tonic/latest/tonic/client/struct.Grpc.html#method.max_decoding_message_size
+const MAX_DECODING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
+
 /// Data types supported by the Snowflake DBMS.
 /// Ref: https://docs.snowflake.com/en/sql-reference/data-types
 #[derive(Debug, Deserialize)]
@@ -155,7 +160,9 @@ pub async fn describe(
             tonic::metadata::MetadataValue::try_from(&dpm_auth_token).unwrap(),
         );
         Ok(req)
-    });
+    })
+    .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE);
+
     let client_version = ClientVersion {
         client: Client::Dpm.into(),
         code_version: built_info::PKG_VERSION.to_string(),


### PR DESCRIPTION
Increase max message decoding size for gRPC client to 32 MB.

### Test plan.
1. [Before fix] Described a source without any table or schema filters to trigger error:
   ```
   connected to https://agent.dpm.sh/
   introspecting ...
   thread 'main' panicked at 'error during `ExecuteQuery`: 
   Status { 
     code: OutOfRange, 
     message: "Error, message length too large: found 4430148 bytes, the limit is: 4194304 bytes", 
     metadata: MetadataMap { headers: {"date": "Fri, 18 Aug 2023 23:04:37 GMT", "content-type": "application/grpc", "grpc-accept-encoding": "identity, deflate, gzip", "strict-transport-security": "max-age=15724800; includeSubDomains"} }, source: None }',
     /Users/ajith/Code/dpm/src/command/snowflake.rs:176:19
   ```
 1. [After fix] The command runs successfully:
     ```
     connected to https://agent.dpm.sh/
     introspecting ...
         warning: omitting column "GEOGRAPHY" of unsupported type Geography from table "DEMO_DB"."SMOKE_TEST"."SMOKE_94C46524_A537_4F0B_A6F5_1AD86492B0A8"
         warning: omitting column "GEOMETRY" of unsupported type Geometry from table "DEMO_DB"."SMOKE_TEST"."SMOKE_94C46524_A537_4F0B_A6F5_1AD86492B0A8"
      ...
     wrote descriptor: datapackage.json
     ```