### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.1.0] - 2023-08-18
+
+### Added
+
+- Initial release

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,4 +37,18 @@ This and other layout choices follow [Rain's Rust CLI recommendations](https://r
 
 ## Publishing
 
-Publishing to a registry (presumably crates.io) is disabled until dpm is minimally functional.
+To create a new release, follow these steps:
+
+1. Examine the changes in the "Unreleased" section of [the changelog](./CHANGELOG.md) and determine the [SemVer](https://semver.org/spec/v2.0.0.html) severity of the release: major, minor, or patch. The rest of these instructions refer to this new version as vX.Y.Z.
+2. Create a "release PR": A PR that:
+   1. Updates the `version` field in the [package's manifest](./Cargo.toml) to be `"X.Y.Z"`.
+   2. Resets the changelog. Do this by duplicating the "Unreleased" section, re-titling the lower duplicate to be `X.Y.Z - <today's date>`, removing empty sections from the new version entry, and removing the items from the sections of "Unreleased".
+3. Merge the release PR.
+4. Create the GitHub release.
+   1. Go to https://github.com/patch-tech/dpm/releases/new, type "vX.Y.Z" in the "Choose a tag" input and select "Create new tag ... on publish".
+   2. Title the release `vX.Y.Z`.
+   3. In the text area, copy/paste the contents of the vX.Y.Z section of the changelog.
+   4. Press **Publish release**.
+5. Create and merge a PR to update [the dpm Homebrew formula](https://github.com/patch-tech/homebrew-tap/blob/main/Formula/dpm.rb). In particular, update the `tag` and `revision` values to be the tag and SHA of the commit associated with the release created in the previous step.
+
+That's it! After completing step 4 [a GitHub workflow](https://github.com/patch-tech/dpm/blob/main/.github/workflows/release.yml) will be triggered that builds release assets and attaches them to the just-created release. This asynchronous work normally takes about 15 minutes to complete.


### PR DESCRIPTION
- Set up the changelog for easy creation of entries
- Document process

No change to Cargo.toml was needed as `0.1.0` has been the version since inception.