### PR TITLE
improve(pat-4032): add source and update helptext

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -71,11 +71,13 @@ enum Command {
         descriptor: PathBuf,
     },
 
+    /// Create and list data sources
     Source {
         #[command(subcommand)]
         action: SourceAction,
     },
 
+    /// Update a data package to a new version
     Update {
         /// Data package descriptor to update
         #[arg(short, long, value_name = "FILE", default_value = "datapackage.json")]

--- a/src/command/source.rs
+++ b/src/command/source.rs
@@ -35,8 +35,10 @@ pub enum CreateSource {
 #[derive(Debug, Subcommand)]
 pub enum SourceAction {
     #[command(subcommand)]
+    /// Create a new source
     Create(CreateSource),
 
+    /// List sources available to this account
     List,
 }
 


### PR DESCRIPTION
dpm help text:
```
Create data packages: libraries tailored to access versioned datasets

Usage: dpm <COMMAND>

Commands:
  describe       Create a data package descriptor that describes some source's data
  build-package  Build a data package from a data package descriptor
  login          Log into DPM Cloud
  publish        Create a data package in DPM Cloud
  source         Create and list data sources
  update         Update a data package to a new version
  completions    Write the tab completion file for a shell
  help           Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
  ```
  source help text:
  ```
  Create and list data sources

Usage: dpm source <COMMAND>

Commands:
  create  Create a new source
  list    List sources available to this account
  help    Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
  ```