### PR TITLE
feat(pat-4033): make login idempotent

### DIFF
--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -24,7 +24,7 @@ pub async fn login() -> Result<()> {
         std::fs::write(&session_path, contents)
             .with_context(|| format!("Error writing session file: {}", session_path.display()))?;
 
-        println!("Session file written to: {}", session_path.display());
+        println!("Session file present at: {}", session_path.display());
         println!("You are now logged in.");
         Ok(())
     }

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -13,7 +13,7 @@ use crate::github;
 pub async fn login() -> Result<()> {
     let session_path = env::session_path()?;
     if session_path.exists() {
-        println!("Session file at: {}", session_path.display());
+        println!("Session file present at: {}", session_path.display());
         println!("You are already logged in.");
         Ok(())
     } else {
@@ -24,7 +24,7 @@ pub async fn login() -> Result<()> {
         std::fs::write(&session_path, contents)
             .with_context(|| format!("Error writing session file: {}", session_path.display()))?;
 
-        println!("Session file present at: {}", session_path.display());
+        println!("Session file written to: {}", session_path.display());
         println!("You are now logged in.");
         Ok(())
     }

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -11,15 +11,21 @@ use crate::github;
 /// issued to the DPM Cloud GitHub App. Then this token is stored on the filesystem,
 /// in a location where running data packages can easily find it.
 pub async fn login() -> Result<()> {
-    let token = github::login().await?;
-    println!();
-
     let session_path = env::session_path()?;
-    let contents = serde_json::to_string_pretty(&token)?;
-    std::fs::write(&session_path, contents)
-        .with_context(|| format!("Error writing session file: {}", session_path.display()))?;
+    if session_path.exists() {
+        println!("Session file at: {}", session_path.display());
+        println!("You are already logged in.");
+        Ok(())
+    } else {
+        let token = github::login().await?;
+        println!();
 
-    println!("Session file written to: {}", session_path.display());
-    println!("You are now logged in.");
-    Ok(())
+        let contents = serde_json::to_string_pretty(&token)?;
+        std::fs::write(&session_path, contents)
+            .with_context(|| format!("Error writing session file: {}", session_path.display()))?;
+
+        println!("Session file written to: {}", session_path.display());
+        println!("You are now logged in.");
+        Ok(())
+    }
 }


### PR DESCRIPTION
when `dpm login` is run, dpm now checks for the existance of the `session.json` path before running login steps.

Test Plan:
1. Removed `session.json` to reset login, then ran the `dpm login` step.
2. Ran the dpm login step again, which outputted:
```
Session file present at: /Users/gunner/Library/Application Support/tech.patch.dpm/session.json
You are already logged in
```