### PR TITLE
feat(pat-4053): enables compiling and executing query

### DIFF
--- a/static/csharp/Dpm/DpmAgentClient.cs
+++ b/static/csharp/Dpm/DpmAgentClient.cs
@@ -88,14 +88,20 @@ namespace Dpm
             return client.ExecuteQueryAsync(request, headers());
         }
 
+        public string CompileQuery(Query request) {
+            Query requestDryRun = request.Clone();
+            requestDryRun.DryRun = true;
+
+            var result = ExecuteQuery(requestDryRun);
+            return result.QueryString;
+        }
+
         Grpc.Core.Metadata headers()
         {
             var md = new Grpc.Core.Metadata();
             if (authToken != null)
             {
-                md.Add(new Grpc.Core.Metadata.Entry(
-                    "dpm-auth-token",
-                    Encoding.UTF8.GetBytes(authToken)));
+                md.Add(new Grpc.Core.Metadata.Entry("dpm-auth-token", authToken));
             }
             return md;
         }


### PR DESCRIPTION
- Adds a `dpm-agent` client to `Table` to enable compiling and executing queries on the source.

### Test plan
1. Generated C# target code from data package descriptor: 
   ```bash
    cargo run build-package -p "Snowflake Demo Package (fast)@0.1.0" -o ~/Sandbox/data-pkgs/rusty/ -y csharp
    ```
2. Built and installed `dotnet nuget` package. In the target output directory:
   ```bash
   dot pack SnowflakeDemoPackageFast.sln
   
   ```
   > ```bash
   >    MSBuild version 17.6.10+2679cf5a9 for .NET
   >    Determining projects to restore...
   >    All projects are up-to-date for restore.
   >    SnowflakeDemoPackageFast -> /Users/ajith/Sandbox/data- 
   >    pkgs/rusty/csharp/SnowflakeDemoPackageFast@0.1.0.0.1.0/SnowflakeDemoPackageFast/bin/Debug/net6.0/SnowflakeDemoPackageFast.dll
   >    /usr/local/share/dotnet/sdk/7.0.307/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5104: A stable release of a package should not have a 
   >    prerelease dependency. Either modify the version spec of dependency "Grpc.Net.Client [2.56.0-pre2, )" or update the version field in the nuspec. [/Users/ajith/Sandbox/data-pkgs/rusty/csharp/SnowflakeDemoPackageFast@0.1.0.0.1.0/SnowflakeDemoPackageFast/SnowflakeDemoPackageFast.csproj]
   >    The package SnowflakeDemoPackageFast.1.0.0 is missing a readme. Go to https://aka.ms/nuget/authoring-best-practices/readme to learn why package readmes are important.
   >    Successfully created package '/Users/ajith/Sandbox/data-pkgs/rusty/csharp/SnowflakeDemoPackageFast@0.1.0.0.1.0/SnowflakeDemoPackageFast/bin/Debug/SnowflakeDemoPackageFast.1.0.0.nupkg'.
    >  ```
3. Enabled local install following instructions at [this](https://stackoverflow.com/a/44463578) SO thread.
4. Created a test project with query file:
    ```c#
       using SnowflakeDemoPackageFast;
       namespace Query
       {
		public class Query
	        {
                 public record Result(float age, string appname);

                 static void Main(string[] args)
                 {
                    var age = FactsAppEngagement.Fields["age"];
                    var appName = FactsAppEngagement.Fields["appname"];

                    var query = FactsAppEngagement.Select(age, appName).Limit(10);
                    var compiledQuery = query.Compile();
                    Console.WriteLine($"compiled query = {compiledQuery}");
        
                    var results = query.Execute<Result>();
                    Console.WriteLine("Rsults = ");
                    foreach (var r in results)
                    {
                       Console.WriteLine(r);
                    }
                 }
            }
       }
     ``` 
5. Observed output on running: `dotnet run`
    ```bash
    Discovering DPM Auth Token from session data.
   compiled query = factsAppEngagementQuery(limit: 10) {
   age
   appname
   }
   Rsults =
   Result { age = 45, appname = com.walmart.android }
   Result { age = 45, appname = com.walmart.android }
   Result { age = 25, appname = com.zhiliaoapp.musically }
   Result { age = 33, appname = com.whatsapp }
   Result { age = 33, appname = com.zhiliaoapp.musically }
   Result { age = 46, appname = com.whatsapp }
   Result { age = 29, appname = com.whatsapp }
   Result { age = 29, appname = com.whatsapp }
   Result { age = 29, appname = com.whatsapp }
   Result { age = 31, appname = com.walmart.android }
   ```