### PR TITLE
feat(pat-4058): support sum aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for C# codegen.
+- Define missing `sum` aggregator for supported targets.
 
 ### Changed
 

--- a/static/csharp/Dpm/Field.cs
+++ b/static/csharp/Dpm/Field.cs
@@ -94,6 +94,14 @@ namespace Dpm
         }
 
         /// <summary>
+        /// Returns a 'sum' aggregation applied to this field.
+        /// </summary>
+        public AggregateFieldExpr<T> Sum()
+        {
+            return new AggregateFieldExpr<T>(this, AggregateOperatorType.sum);
+        }
+
+        /// <summary>
         /// Returns a 'count' aggregation applied to this field.
         /// </summary>
         public AggregateFieldExpr<int> Count()

--- a/static/csharp/Dpm/LiteralField.cs
+++ b/static/csharp/Dpm/LiteralField.cs
@@ -116,6 +116,11 @@ namespace Dpm
       throw new NotImplementedException("Cannot call Min on LiteralField");
     }
 
+    public new AggregateFieldExpr<T> Sum()
+    {
+      throw new NotImplementedException("Cannot call Sum on LiteralField");
+    }
+
     public new AggregateFieldExpr<T> Count()
     {
       throw new NotImplementedException("Cannot call Count on LiteralField");

--- a/static/csharp/DpmTest/UnitTest1.cs
+++ b/static/csharp/DpmTest/UnitTest1.cs
@@ -41,7 +41,7 @@ namespace DpmTest
             DateField startedAt = new("startedAt");
             StringField name = new("name");
             Field<float> price = new("price");
-            Table t = new Table(
+            Table t = new(
                 packageId: "1124-111",
                 datasetName: "my_dataset",
                 datasetVersion: "0.1.0",

--- a/static/nodejs/src/backends/dpm_agent/dpm_agent_client.ts
+++ b/static/nodejs/src/backends/dpm_agent/dpm_agent_client.ts
@@ -58,6 +58,7 @@ function makeDpmFieldReference(field: FieldExpr): DpmAgentQuery.FieldReference {
 const aggregateOperatorMap = {
   min: DpmAgentQuery.AggregateExpression.AggregateOperator.MIN,
   max: DpmAgentQuery.AggregateExpression.AggregateOperator.MAX,
+  sum: DpmAgentQuery.AggregateExpression.AggregateOperator.SUM,
   count: DpmAgentQuery.AggregateExpression.AggregateOperator.COUNT,
   countDistinct:
     DpmAgentQuery.AggregateExpression.AggregateOperator.COUNT_DISTINCT,

--- a/static/nodejs/src/field.ts
+++ b/static/nodejs/src/field.ts
@@ -73,6 +73,13 @@ export class Field<T extends Scalar> extends FieldExpr {
   }
 
   /**
+   * Returns a `sum` aggregation applied on this field.
+   */
+  sum(): AggregateFieldExpr<number> {
+    return new AggregateFieldExpr<number>(this, 'sum');
+  }
+
+  /**
    * Returns an `count` aggregation applied on this field.
    */
   count(): AggregateFieldExpr<number> {
@@ -202,6 +209,10 @@ export class LiteralField<T extends Scalar> extends Field<T> {
 
   override min(): never {
     throw new SyntaxError('Cannot call min on literal field');
+  }
+
+  override sum(): never {
+    throw new SyntaxError('Cannot call sum on literal field');
   }
 
   override count(): never {

--- a/static/nodejs/src/field_expr.ts
+++ b/static/nodejs/src/field_expr.ts
@@ -24,6 +24,7 @@ export type ArithmeticOperator = '+' | '-' | '*' | '/';
 export type AggregateOperator =
   | 'min'
   | 'max'
+  | 'sum'
   | 'count'
   | 'countDistinct'
   | 'avg'

--- a/static/nodejs/test/field.test.ts
+++ b/static/nodejs/test/field.test.ts
@@ -32,6 +32,11 @@ describe('Field', () => {
     expect(maxPrice instanceof AggregateFieldExpr).toBeTruthy();
     expect(maxPrice.operands()).toStrictEqual([price]);
     expect(maxPrice.operator()).toBe('avgDistinct');
+
+    const totalPrice = price.sum();
+    expect(totalPrice instanceof AggregateFieldExpr).toBeTruthy();
+    expect(totalPrice.operands()).toStrictEqual([price]);
+    expect(totalPrice.operator()).toBe('sum');
   });
 });
 

--- a/static/python/src/backends/dpm_agent/dpm_agent_client.py
+++ b/static/python/src/backends/dpm_agent/dpm_agent_client.py
@@ -56,6 +56,7 @@ def make_dpm_field_reference(field: FieldExpr) -> DpmAgentQuery.FieldReference:
 AGGREGATE_OPERATOR_MAP = {
     "min": DpmAgentQuery.AggregateExpression.MIN,
     "max": DpmAgentQuery.AggregateExpression.MAX,
+    "sum": DpmAgentQuery.AggregateExpression.SUM,
     "count": DpmAgentQuery.AggregateExpression.COUNT,
     "countDistinct": DpmAgentQuery.AggregateExpression.COUNT_DISTINCT,
     "avg": DpmAgentQuery.AggregateExpression.MEAN,

--- a/static/python/src/field.py
+++ b/static/python/src/field.py
@@ -66,6 +66,10 @@ class Field(FieldExpr):
         """Returns a `min` aggregation applied on this field."""
         return AggregateFieldExpr(self, "min")
 
+    def sum(self) -> AggregateFieldExpr:
+        """Returns a `sum` aggregation applied on this field."""
+        return AggregateFieldExpr(self, "sum")
+
     def count(self) -> AggregateFieldExpr:
         """Returns a `count` aggregation applied on this field."""
         return AggregateFieldExpr(self, "count")
@@ -145,6 +149,9 @@ class LiteralField(Field):
 
     def min(self):
         raise SyntaxError("Cannot call min on literal field")
+
+    def sum(self):
+        raise SyntaxError("Cannot call sum on literal field")
 
     def count(self):
         raise SyntaxError("Cannot call count on literal field")

--- a/static/python/src/field_expr.py
+++ b/static/python/src/field_expr.py
@@ -1,10 +1,7 @@
 from typing import Any, Callable, Union, List, Optional, Literal, TypeVar
 
 Scalar = Union[str, int, float, bool]
-UnaryOperator = Union[
-    Literal["isNull"],
-    Literal["isNotNull"]
-]
+UnaryOperator = Union[Literal["isNull"], Literal["isNotNull"]]
 BooleanOperator = Union[
     Literal["eq"],
     Literal["neq"],
@@ -17,7 +14,11 @@ BooleanOperator = Union[
 ]
 ArithmeticOperator = Union[Literal["+"], Literal["-"], Literal["*"], Literal["/"]]
 AggregateOperator = Union[
-    Literal["min"], Literal["max"], Literal["count"], Literal["countDistinct"]
+    Literal["min"],
+    Literal["max"],
+    Literal["sum"],
+    Literal["count"],
+    Literal["countDistinct"],
 ]
 DateOperator = Union[Literal["years"], Literal["months"], Literal["days"]]
 TimeOperator = Union[
@@ -35,7 +36,6 @@ Operator = Union[UnaryOperator, BooleanOperator, ArithmeticOperator, AggregateOp
 
 
 class FieldExpr:
-
     name: str
     # User-specified alias for expression. Can be used in a `select` and then in
     # a subsequent `order_by`.
@@ -51,8 +51,9 @@ class FieldExpr:
     def operator(self) -> Operator:
         pass
 
-    def operands(self) -> List[Union['FieldExpr', Scalar]]:
+    def operands(self) -> List[Union["FieldExpr", Scalar]]:
         return []
+
 
 Expr = Union[Scalar, FieldExpr]
 
@@ -85,8 +86,8 @@ class BooleanFieldExpr(FieldExpr):
 
     def __or__(self, that: FieldExpr) -> "BooleanFieldExpr":  # |
         return BooleanFieldExpr(self, "or", that)
-    
-    
+
+
 class UnaryBooleanFieldExpr(FieldExpr):
     def __init__(self, field: FieldExpr, op: UnaryOperator) -> None:
         """
@@ -105,13 +106,12 @@ class UnaryBooleanFieldExpr(FieldExpr):
 
     def __or__(self, that: FieldExpr) -> "BooleanFieldExpr":  # |
         return BooleanFieldExpr(self, "or", that)
-    
+
     def operator(self) -> Operator:
         return self.op
 
     def operands(self) -> List[Expr]:
         return [self.field]
-
 
 
 class AggregateFieldExpr(FieldExpr):
@@ -153,7 +153,7 @@ class AggregateFieldExpr(FieldExpr):
         Returns:
             An `AggregateFieldExpr` object with the specified alias.
         """
-        copy =  AggregateFieldExpr(self.field, self.op)
+        copy = AggregateFieldExpr(self.field, self.op)
         copy.alias = alias
         return copy
 

--- a/static/python/src/test/field_test.py
+++ b/static/python/src/test/field_test.py
@@ -34,6 +34,11 @@ def test_field_returns_the_correct_aggregate_expression():
     assert max_price.operands() == [price]
     assert max_price.operator() == "avgDistinct"
 
+    total_price = price.sum()
+    assert isinstance(total_price, AggregateFieldExpr)
+    assert total_price.operands() == [price]
+    assert total_price.operator() == "sum"
+
 
 def test_derived_field_as_returns_copy_of_derived_field_and_does_not_mutate_this():
     started_on = DateField("startedOn")


### PR DESCRIPTION
- Support `sum` aggregator.

## Test plan.
- Updated unit tests.
- Ran a query that includes `sum` via `dpm-agent` for each target.
   - C#
 
    ```bash
     ajith@ajiths-mbp  ~/Sandbox/gen-patchage/ts/testbed/UsImports/csharp  dotnet run
     Discovering DPM Auth Token from session data.
     compiled query = factsAppEngagementQuery(filter: { and: [{ age: { lt: 50 } },
     { appname: { like: "%walmart%" } }] }, orderBy: 
     [{screenondurationMax: desc}], limit: 10) {
     age
     appname
     totalScreenTime: screenondurationSum
     screenDurationMax: screenondurationMax
    }
   Results =
   Result { age = 21, appname = com.walmart.android, 
      totalScreenTime = 1757310343.0, screenDurationMax = 65988384 }
    Result { age = 46, appname = com.walmart.android, 
      totalScreenTime = 10797960489.0, screenDurationMax = 6.436366E+7 }
    Result { age = 42, appname = com.walmart.android, totalScreenTime = 11
    ```
   - NodeJS
    ```bash
    (py3)  ajith@ajiths-mbp  ~/Sandbox/gen-patchage/ts/testbed/UsImports/nodejs  time npx ts-node query.ts
    Attempting to connect to https://agent.dpm.sh
    factsAppEngagementQuery(filter: { and: [{ age: { ne: null } },
    { devicemakemodel: { like: "samsung%" } }] }, orderBy: [{ageMax: desc}], limit: 10) {
      appTitle
      meanTimeInApp: foregrounddurationAvg
      totalTimeInApp: foregrounddurationSum
      userCount: panelistidCountDistinct
      day: starttimestampDay
      maxAge: ageMax
    }
    [{
      appTitle: 'Cash App',
      meanTimeInApp: '88838.08703220191470844212358573',
      totalTimeInApp: '204149924.0',
      userCount: 814,
      day: 8,
      maxAge: 89
    },
    ...
    ```
  - Python
   ```bash
    INFO:snowflake_demo_package_fast.backends.dpm_agent.dpm_agent_client:Attempting to connect to https://agent.dpm.sh
   Compiled query:
    factsAppEngagementQuery(limit: 10) {
     App_Name: appTitle
     Mean_Time_in_App: foregrounddurationAvg
     Total_Time_in_App: foregrounddurationSum
     User_Count: panelistidCountDistinct
     Day_of_Week: starttimestampDay
   }
   Results:
    [{'App_Name': 'Tik Tok',
      'Day_of_Week': 5,
      'Mean_Time_in_App': '214033.11440456820065698584717404',
      'Total_Time_in_App': '13943401271.0',
      'User_Count': 3188},
     . . .
   ```