### PR TITLE
feat(build-package): Accept descriptor OR reference to published package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `build-package`: Add new target: C#.
+- `build-package`: Add `sum` aggregator to all targets.
+- `build-package`: Support building instances both from a descriptor ("draft packages") and from a reference to a published package ("standard packages").
 
 ### Changed
 


### PR DESCRIPTION
- Restore the ability to run `build-package` off of a descriptor

This ability was removed in https://github.com/patch-tech/dpm/pull/113, but that was a detriment to UX: it resulted in a design where one must run `dpm publish` in order to build a package. That was untenable since it took away the ability for a user to QA their data package prior to publishing.

## Test plan

Help output:
```
% cargo run -- build-package --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
     Running `target/debug/dpm build-package --help`
Build an instance of a data package.

There are two different ways to specify the package to build:

1. By default (or with -d/--descriptor <FILE>) a package descriptor file
   on the filesystem is used to define the tables and fields accessible
   by the package.
2. With -p/--package <PACKAGE_REF>, an instance of the referenced,
   published package is built.

A package created via (1) is called a draft data package. It is only
usable by the DPM Cloud user that created it; queries made by any other
principal will not be authorized.

A package created via (2) is called a standard data package. Queries
made using it will be authorized if and only if the package's
authorization policy in DPM Cloud allows querying by the given
principal.

Usage: dpm build-package [OPTIONS] <COMMAND>

Commands:
  nodejs  Build a Node.js data package
  python  Build a Python data package
  csharp  Build a C# data package
  help    Print this message or the help of the given subcommand(s)

Options:
  -d, --descriptor <FILE>
          Data package descriptor to read

          [default: datapackage.json]

  -p, --package <PACKAGE_REF>
          Data package identifier: "<package name>@<version>". Conflicts with --descriptor

  -o, --out-dir <DIR>
          Directory to write build artifacts to

          [default: dist]

  -y, --yes
          Automatically respond "yes" to any prompts

  -h, --help
          Print help (see a summary with '-h')
```

Building off of a datapackage.json, file exists:
```
% cargo run -- build-package nodejs
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/dpm build-package nodejs`
Going to generate a data-package in NodeJs { scope: None }
Data package already exists at "dist/nodejs/my-pkg@0.2.0-0.2.0", overwrite? yes
Overwriting
Wrote asset ".prettierrc" to "dist/nodejs/my-pkg@0.2.0-0.2.0/.prettierrc"
Wrote asset "src/backends/dpm_agent/dpm_agent_client.ts" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/backends/dpm_agent/dpm_agent_client.ts"
Wrote asset "src/backends/dpm_agent/dpm_agent_grpc_pb.d.ts" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/backends/dpm_agent/dpm_agent_grpc_pb.d.ts"
Wrote asset "src/backends/dpm_agent/dpm_agent_grpc_pb.js" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/backends/dpm_agent/dpm_agent_grpc_pb.js"
Wrote asset "src/backends/dpm_agent/dpm_agent_pb.d.ts" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/backends/dpm_agent/dpm_agent_pb.d.ts"
Wrote asset "src/backends/dpm_agent/dpm_agent_pb.js" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/backends/dpm_agent/dpm_agent_pb.js"
Wrote asset "src/backends/env.ts" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/backends/env.ts"
Wrote asset "src/backends/factory.ts" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/backends/factory.ts"
Wrote asset "src/backends/interface.ts" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/backends/interface.ts"
Wrote asset "src/field.ts" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/field.ts"
Wrote asset "src/field_expr.ts" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/field_expr.ts"
Wrote asset "src/table.ts" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/table.ts"
Wrote asset "src/version.ts" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/version.ts"
Wrote asset "tsconfig.json" to "dist/nodejs/my-pkg@0.2.0-0.2.0/tsconfig.json"
Wrote table definition "BoolTest" for resource "BOOL_TEST" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/bool_test.ts"
Wrote table definition "FiftyMilInt" for resource "FIFTY_MIL_INT" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/fifty_mil_int.ts"
Wrote table definition "FiveMilInt" for resource "FIVE_MIL_INT" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/five_mil_int.ts"
Wrote table definition "LineitemBig" for resource "LINEITEM_BIG" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/lineitem_big.ts"
Wrote table definition "LineitemBigPk" for resource "LINEITEM_BIG_PK" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/lineitem_big_pk.ts"
Wrote table definition "OneHundredMilInt" for resource "ONE_HUNDRED_MIL_INT" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/one_hundred_mil_int.ts"
Wrote table definition "OneMilInt" for resource "ONE_MIL_INT" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/one_mil_int.ts"
Wrote table definition "Region" for resource "REGION" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/region.ts"
Wrote table definition "RegionNoNum" for resource "REGION_NO_NUM" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/region_no_num.ts"
Wrote table definition "TenMilInt" for resource "TEN_MIL_INT" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/ten_mil_int.ts"
Wrote table definition "TwentyMilInt" for resource "TWENTY_MIL_INT" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/twenty_mil_int.ts"
Wrote table definition "UkRealEstate3" for resource "UK_REAL_ESTATE_3" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/uk_real_estate_3.ts"
Wrote table definition "UkRealEstateRecords" for resource "UK_REAL_ESTATE_RECORDS" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/uk_real_estate_records.ts"
Wrote table definition "UkRealEstateRecords14" for resource "UK_REAL_ESTATE_RECORDS_1_4" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/uk_real_estate_records_14.ts"
Wrote table definition "UkRealEstateRecords2" for resource "UK_REAL_ESTATE_RECORDS_2" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/uk_real_estate_records_2.ts"
Wrote table definition "UkRealEstateRecordsFl" for resource "UK_REAL_ESTATE_RECORDS_FL" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/uk_real_estate_records_fl.ts"
Wrote table definition "UniqueLineitem" for resource "UNIQUE_LINEITEM" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/unique_lineitem.ts"
Wrote table definition "UniqueLineitemSingle" for resource "UNIQUE_LINEITEM_SINGLE" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/unique_lineitem_single.ts"
Wrote table definition "UsImportsCargoDetails" for resource "US_IMPORTS_CARGO_DETAILS" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/us_imports_cargo_details.ts"
Wrote table definition "UsImportsContainerDetails" for resource "US_IMPORTS_CONTAINER_DETAILS" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/us_imports_container_details.ts"
Wrote table definition "UsImportsPartyDetails" for resource "US_IMPORTS_PARTY_DETAILS" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/us_imports_party_details.ts"
Wrote table definition "UsImportsPrimaryDetails" for resource "US_IMPORTS_PRIMARY_DETAILS" to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/tables/us_imports_primary_details.ts"
Wrote version to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/version.ts"
Wrote entry code to "dist/nodejs/my-pkg@0.2.0-0.2.0/src/index.ts"
Wrote manifest to "dist/nodejs/my-pkg@0.2.0-0.2.0/package.json"
Building npm package
```
Build off of a datapackage.json, file does not exist (to be improved via [PAT-3694](https://linear.app/patch-tech/issue/PAT-3694/improve-error-handling-reporting)):
```
% cargo run -- build-package nodejs
   Compiling dpm v0.1.0 (/Users/spencer/code/dpm)
    Finished dev [unoptimized + debuginfo] target(s) in 5.04s
     Running `target/debug/dpm build-package nodejs`
thread 'main' panicked at 'Error reading datapackage.json: No such file or directory (os error 2)', /Users/spencer/code/dpm/src/command.rs:192:35
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Building off of a published package:
```
% cargo run -- build-package -p "Snowflake Demo Package@0.1.0" nodejs
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/dpm build-package -p 'Snowflake Demo Package@0.1.0' nodejs`
Going to generate a data-package in NodeJs { scope: None }
Data package already exists at "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0", overwrite? yes
Overwriting
Wrote asset ".prettierrc" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/.prettierrc"
Wrote asset "src/backends/dpm_agent/dpm_agent_client.ts" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/backends/dpm_agent/dpm_agent_client.ts"
Wrote asset "src/backends/dpm_agent/dpm_agent_grpc_pb.d.ts" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/backends/dpm_agent/dpm_agent_grpc_pb.d.ts"
Wrote asset "src/backends/dpm_agent/dpm_agent_grpc_pb.js" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/backends/dpm_agent/dpm_agent_grpc_pb.js"
Wrote asset "src/backends/dpm_agent/dpm_agent_pb.d.ts" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/backends/dpm_agent/dpm_agent_pb.d.ts"
Wrote asset "src/backends/dpm_agent/dpm_agent_pb.js" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/backends/dpm_agent/dpm_agent_pb.js"
Wrote asset "src/backends/env.ts" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/backends/env.ts"
Wrote asset "src/backends/factory.ts" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/backends/factory.ts"
Wrote asset "src/backends/interface.ts" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/backends/interface.ts"
Wrote asset "src/field.ts" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/field.ts"
Wrote asset "src/field_expr.ts" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/field_expr.ts"
Wrote asset "src/table.ts" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/table.ts"
Wrote asset "src/version.ts" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/version.ts"
Wrote asset "tsconfig.json" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/tsconfig.json"
Wrote table definition "FactsAppEngagement" for resource "FACTS_APP_ENGAGEMENT" to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/tables/facts_app_engagement.ts"
Wrote version to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/version.ts"
Wrote entry code to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/src/index.ts"
Wrote manifest to "dist/nodejs/snowflake-demo-package@0.1.0-0.2.0/package.json"
Building npm package
```