### PR TITLE
feat(build-package): Create draft versions when building from local descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `build-package`: Add new target: C#.
-- `build-package`: Add `sum` aggregator to all targets.
-- `build-package`: Support building instances both from a descriptor ("draft packages") and from a reference to a published package ("standard packages").
+- `build-package`: Support building instances both from a descriptor ("draft
+packages") and from a reference to a published package ("release packages").
 
 ### Changed
 

--- a/src/codegen/csharp.rs
+++ b/src/codegen/csharp.rs
@@ -436,7 +436,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::{api::PackageVersion, command::read_data_package};
+    use crate::{api::PackageVersion, descriptor::DataPackage};
 
     #[test]
     fn clean_name_works() {
@@ -450,7 +450,7 @@ mod tests {
 
     #[test]
     fn root_dir_works() {
-        let dp = read_data_package("tests/resources/datapackage.json").unwrap();
+        let dp = DataPackage::read("tests/resources/datapackage.json").unwrap();
         let res = GetPackageVersionResponse {
             package_name: dp.name.to_string(),
             package_uuid: Uuid::from_bytes(dp.id.as_bytes().to_owned()),

--- a/src/codegen/nodejs.rs
+++ b/src/codegen/nodejs.rs
@@ -534,7 +534,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::{api::PackageVersion, command::read_data_package};
+    use crate::{api::PackageVersion, descriptor::DataPackage};
 
     #[test]
     fn standardize_import_works() {
@@ -564,7 +564,7 @@ mod tests {
 
     #[test]
     fn root_dir_works() {
-        let dp = read_data_package("tests/resources/datapackage.json").unwrap();
+        let dp = DataPackage::read("tests/resources/datapackage.json").unwrap();
         let res = GetPackageVersionResponse {
             package_name: dp.name.to_string(),
             package_uuid: Uuid::from_bytes(dp.id.as_bytes().to_owned()),

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -529,7 +529,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::{api::PackageVersion, command::read_data_package};
+    use crate::{api::PackageVersion, descriptor::DataPackage};
 
     #[test]
     fn standardize_import_works() {
@@ -559,7 +559,7 @@ mod tests {
 
     #[test]
     fn root_dir_works() {
-        let dp = read_data_package("tests/resources/datapackage.json").unwrap();
+        let dp = DataPackage::read("tests/resources/datapackage.json").unwrap();
         let res = GetPackageVersionResponse {
             package_name: dp.name.to_string(),
             package_uuid: Uuid::from_bytes(dp.id.as_bytes().to_owned()),

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,24 +1,21 @@
 //! Command parsers and logic.
 
-use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
-use semver::Version;
-use std::fs::{create_dir_all, File};
-use std::io::{self, BufReader};
-use std::path::{Path, PathBuf};
 
+use std::io;
+use std::path::PathBuf;
+
+mod build_package;
 mod describe;
 mod login;
 mod publish;
 pub mod snowflake;
 mod source;
 mod update;
-use crate::api::{GetPackageVersionResponse, PackageVersion};
-use crate::{api::Client, session};
 
 use self::source::SourceAction;
-use super::codegen::{generate_package, Target};
-use super::descriptor::{DataPackage, Name};
+use super::codegen::Target;
+use super::descriptor::Name;
 use clap_complete::{self, generate, Shell};
 
 #[derive(Subcommand, Debug)]
@@ -57,7 +54,7 @@ enum Command {
     /// usable by the DPM Cloud user that created it; queries made by any other
     /// principal will not be authorized.
     ///
-    /// A package created via (2) is called a standard data package. Queries
+    /// A package created via (2) is called a release data package. Queries
     /// made using it will be authorized if and only if the package's
     /// authorization policy in DPM Cloud allows querying by the given
     /// principal.
@@ -122,27 +119,6 @@ pub struct App {
     command: Command,
 }
 
-/// Reads datapackage.json at path and returns a deserialized instance of DataPackage.
-/// Modified from example code at: https://docs.rs/serde_json/latest/serde_json/fn.from_reader.html#example
-pub fn read_data_package<P: AsRef<Path>>(path: P) -> Result<DataPackage> {
-    let file = File::open(path)?;
-    let reader = BufReader::new(file);
-
-    let data_package = serde_json::from_reader(reader)?;
-    Ok(data_package)
-}
-
-/// Checks that the output directory exists and is accessible.
-fn check_output_dir(p: &Path) {
-    match p.try_exists() {
-        Ok(v) if !v => panic!("Output directory {:?} does not exist", p),
-        Err(e) => {
-            panic!("Error accessing output directory {e}")
-        }
-        _ => {}
-    }
-}
-
 fn print_completions<G: clap_complete::Generator>(gen: G, cmd: &mut clap::Command) {
     generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
 }
@@ -171,40 +147,12 @@ impl App {
                 out_dir,
                 assume_yes,
             } => {
-                // `descriptor` is always defined (possibly via its
-                // default_value), whereas the caller may instead opt to build a
-                // published package via -p. Before reaching this function, clap
-                // will have verified that if -p was given, -d was not given.
-                let build_input: GetPackageVersionResponse = if let Some(package_ref) = package {
-                    let package_identifier: Vec<&str> = package_ref.split('@').collect();
-                    let version: Version = Version::parse(package_identifier[1])
-                        .expect("package identifier `version` is invalid");
-                    let session = session::get_token().expect("unable to get session");
-                    let client = Client::new(&session).expect("unable to get client");
-
-                    client
-                        .get_package_version(package_identifier[0], version)
-                        .await
-                        .expect("failed to fetch package")
-                } else {
-                    let dp = match read_data_package(&descriptor) {
-                        Ok(dp) => dp,
-                        Err(e) => panic!("Error reading {}: {}", descriptor.display(), e),
-                    };
-                    GetPackageVersionResponse {
-                        package_name: dp.name.to_string(),
-                        package_uuid: uuid::Uuid::parse_str(&dp.id.to_string()).unwrap(),
-                        package_description: dp.description.unwrap_or("".into()),
-                        version: PackageVersion {
-                            version: dp.version,
-                            dataset: dp.dataset,
-                        },
-                    }
-                };
-
-                create_dir_all(&out_dir).expect("error creating output directory");
-                check_output_dir(&out_dir);
-                generate_package(&build_input, &target, &out_dir, assume_yes);
+                if let Err(e) =
+                    build_package::build(descriptor, package, target, out_dir, assume_yes).await
+                {
+                    eprintln!("package build failed: {:#}", e);
+                    std::process::exit(1);
+                }
             }
             Command::Login => {
                 if let Err(source) = login::login().await {

--- a/src/command/build_package.rs
+++ b/src/command/build_package.rs
@@ -1,0 +1,91 @@
+use std::{
+    fs::create_dir_all,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{bail, Context, Result};
+use semver::Version;
+
+use crate::{
+    api::{Client, CreatePackageVersion, GetPackageVersionResponse},
+    codegen::{generate_package, Target},
+    descriptor::DataPackage,
+    session,
+};
+
+pub async fn build(
+    descriptor: PathBuf,
+    package: Option<String>,
+    target: Target,
+    out_dir: PathBuf,
+    assume_yes: bool,
+) -> Result<()> {
+    let session = session::get_token().expect("unable to get session");
+    let client = Client::new(&session).expect("unable to get client");
+
+    // `descriptor` is always defined (possibly via its
+    // default_value), whereas the caller may instead opt to build a
+    // published package via -p. Before reaching this function, clap
+    // will have verified that if -p was given, -d was not given.
+    let build_input: GetPackageVersionResponse = if let Some(package_ref) = package {
+        let package_identifier: Vec<&str> = package_ref.split('@').collect();
+        if package_identifier.len() != 2 {
+            bail!("invalid -p value; expected \"<package name>@<version>\"")
+        }
+        let version: Version =
+            Version::parse(package_identifier[1]).expect("package identifier `version` is invalid");
+
+        client
+            .get_package_version(package_identifier[0], version)
+            .await
+            .expect("failed to fetch package")
+    } else {
+        let dp = DataPackage::read(&descriptor)
+            .with_context(|| format!("failed to read {}", descriptor.display()))?;
+
+        eprintln!("creating draft version of {}@{}", dp.name, dp.version);
+
+        let created_version = client
+            .create_version(
+                dp.id,
+                &dp.version,
+                &CreatePackageVersion {
+                    name: &dp.name,
+                    draft: true,
+                    description: &dp.description.clone().unwrap_or("".into()),
+                    dataset: &dp.dataset,
+                },
+            )
+            .await?;
+
+        eprintln!(
+            "draft version created: {}@{}",
+            dp.name, created_version.version
+        );
+        eprintln!("tip: Your drafts are queryable only by you. To enable access by others, create a release version with `dpm publish`.");
+
+        GetPackageVersionResponse {
+            package_name: dp.name.to_string(),
+            package_uuid: uuid::Uuid::parse_str(&dp.id.to_string()).unwrap(),
+            package_description: dp.description.unwrap_or("".into()),
+            version: created_version,
+        }
+    };
+
+    create_dir_all(&out_dir).expect("error creating output directory");
+    check_output_dir(&out_dir);
+    generate_package(&build_input, &target, &out_dir, assume_yes);
+
+    Ok(())
+}
+
+/// Checks that the output directory exists and is accessible.
+fn check_output_dir(p: &Path) {
+    match p.try_exists() {
+        Ok(v) if !v => panic!("Output directory {:?} does not exist", p),
+        Err(e) => {
+            panic!("Error accessing output directory {e}")
+        }
+        _ => {}
+    }
+}

--- a/src/command/publish.rs
+++ b/src/command/publish.rs
@@ -2,10 +2,10 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use crate::{api, command::read_data_package, session};
+use crate::{api, descriptor::DataPackage, session};
 
 pub async fn publish(descriptor_path: &Path) -> Result<()> {
-    let package = read_data_package(descriptor_path)
+    let package = DataPackage::read(descriptor_path)
         .with_context(|| format!("Failed to read descriptor at {}", descriptor_path.display()))?;
 
     let token = session::get_token()?;
@@ -17,6 +17,7 @@ pub async fn publish(descriptor_path: &Path) -> Result<()> {
             &package.version,
             &api::CreatePackageVersion {
                 name: &package.name,
+                draft: false,
                 description: &package.description.unwrap_or("".into()),
                 dataset: &package.dataset,
             },

--- a/src/command/update.rs
+++ b/src/command/update.rs
@@ -1,9 +1,4 @@
-use std::{
-    ffi::OsString,
-    fs::File,
-    io::BufReader,
-    path::{Path, PathBuf},
-};
+use std::{ffi::OsString, path::PathBuf};
 
 use anyhow::{Context, Result};
 use dialoguer::Confirm;
@@ -12,17 +7,8 @@ use crate::descriptor::{DataPackage, DataResource, SourcePath, TableSchema, Tabl
 
 use super::snowflake;
 
-/// Reads datapackage.json at path and returns a deserialized instance of DataPackage.
-fn read_data_package<P: AsRef<Path>>(path: P) -> Result<DataPackage> {
-    let file = File::open(path)?;
-    let reader = BufReader::new(file);
-
-    let data_package = serde_json::from_reader(reader).context("deserialization failed")?;
-    Ok(data_package)
-}
-
 pub async fn update(base_path: &PathBuf) -> Result<()> {
-    let current_dp = read_data_package(base_path)
+    let current_dp = DataPackage::read(base_path)
         .with_context(|| format!("failed to read {}", base_path.display()))?;
 
     let source_id = current_dp

--- a/src/descriptor/data_package.rs
+++ b/src/descriptor/data_package.rs
@@ -1,4 +1,6 @@
-use anyhow::bail;
+use std::{fs::File, io::BufReader, path::Path};
+
+use anyhow::{bail, Context, Result};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -33,6 +35,17 @@ pub struct DataPackage {
     pub description: Option<String>,
     pub version: Version,
     pub dataset: Vec<DataResource>,
+}
+
+impl DataPackage {
+    /// Reads datapackage.json at path and returns a deserialized instance of DataPackage.
+    pub fn read<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+
+        let data_package = serde_json::from_reader(reader).context("deserialization failed")?;
+        Ok(data_package)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
- Move `build-package` handler to its own module
- Delete duplicate `read_data_package` implementations and move to a method on `DataPackage`
- Only create release versions if generating from a published version; create draft versions otherwise

There will be one PR to follow this one, updating the codegen to work with `Version`'s that have prerelease data on them. (NB(ajith): This is already completed in [PR 151](https://app.graphite.dev/github/pr/patch-tech/dpm/151/fix-pat-4301-c-version-tag))