### PR TITLE
feat(pat-4226): cmd to build c# nuget package

### DIFF
--- a/src/codegen/csharp.rs
+++ b/src/codegen/csharp.rs
@@ -424,12 +424,9 @@ impl Generator for Csharp<'_> {
             &["sln", "add", &pkg_name],
         );
 
-        exec_cmd(
-            "building with dotnet",
-            path,
-            "dotnet",
-            &["build"], // TODO: complete args.
-        );
+        exec_cmd("building with dotnet", path, "dotnet", &["build"]);
+
+        exec_cmd("creating nupkg", path, "dotnet", &["pack"]);
     }
 }
 


### PR DESCRIPTION
- Add command to build dotnet nuget package.

### Test plan
- Built c# package and verified that the `.nupkg` was created:
`cargo run build-package -p "Snowflake Demo Package (fast)@0.1.0" -o ~/Sandbox/data-pkgs/rusty/ -y csharp`
- 
```bash
   > ls -lh SnowflakeDemoPackageFast/bin/Debug/SnowflakeDemoPackageFast.1.0.0.nupkg
   -rw-r--r--  1 ajith  staff    47K Sep 11 11:42 SnowflakeDemoPackageFast/bin/Debug/SnowflakeDemoPackageFast.1.0.0.nupkg
```