### PR TITLE
fix(pat-4301): c# version tag

### DIFF
--- a/src/codegen/csharp.rs
+++ b/src/codegen/csharp.rs
@@ -332,7 +332,7 @@ impl Generator for Csharp<'_> {
     fn root_dir(&self) -> PathBuf {
         let dp = self.data_package();
         let package_directory = format!(
-            "{}@{}.{}",
+            "{}@{}-{}",
             self.package_name(&dp.package_name),
             dp.version.version,
             CSHARP_VERSION
@@ -373,7 +373,7 @@ impl Generator for Csharp<'_> {
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <ReleaseVersion>{version}</ReleaseVersion>
+    <Version>{version}</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -461,7 +461,7 @@ mod tests {
             },
         };
         let generator = Box::new(Csharp::new(&res));
-        let expected_dir = format!("TestSnowflake@0.1.0.{}", CSHARP_VERSION);
+        let expected_dir = format!("TestSnowflake@0.1.0-{}", CSHARP_VERSION);
         assert_eq!(generator.root_dir(), Path::new("csharp").join(expected_dir));
     }
 }

--- a/tests/nodejs/package-lock.json
+++ b/tests/nodejs/package-lock.json
@@ -3591,7 +3591,7 @@
     "node_modules/test-snowflake": {
       "version": "0.1.0-0.2.0",
       "resolved": "file:../resources/generated/nodejs/test-snowflake-0.1.0-0.2.0.tgz",
-      "integrity": "sha512-nMw6hbdb+gigVxr19sVuBxK9T8aeypsLZV3pfpYDTf+vMU/P55fOCicXY2cj3Y2frbyRaorFy8x/spC4gYWt5w==",
+      "integrity": "sha512-OdJ5FYi2alpz81CNH4pN78JM6zWfVZWBa6w1jWOa0dTNJQG8tRa79oSz+qk977kIjXzp76viW04Jy8ifzd09FA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.1.0",
         "@grpc/proto-loader": "^0.5.0",
@@ -6637,7 +6637,7 @@
     },
     "test-snowflake": {
       "version": "file:../resources/generated/nodejs/test-snowflake-0.1.0-0.2.0.tgz",
-      "integrity": "sha512-nMw6hbdb+gigVxr19sVuBxK9T8aeypsLZV3pfpYDTf+vMU/P55fOCicXY2cj3Y2frbyRaorFy8x/spC4gYWt5w==",
+      "integrity": "sha512-OdJ5FYi2alpz81CNH4pN78JM6zWfVZWBa6w1jWOa0dTNJQG8tRa79oSz+qk977kIjXzp76viW04Jy8ifzd09FA==",
       "requires": {
         "@grpc/grpc-js": "^1.1.0",
         "@grpc/proto-loader": "^0.5.0",


### PR DESCRIPTION
- Update C# root dir path to use correct version string format `{pkg-semver}-{code-semver}`
- Use `<Version>` tag in `.csproj`; `<ReleaseVersion>` does not work.

### Test plan
- Built C# package and verified that the correct path was used for the target, and the .csproj had the expected `<Version>` tag.
- Created the `.nupkg` and added it to a test project; verified that the `<PackageReference>` in the test `.csproj` had the expected semver.