### PR TITLE
fix(describe): Omit Snowflake's ARRAY, OBJECT, and VARIANT types

### DIFF
--- a/src/codegen/csharp.rs
+++ b/src/codegen/csharp.rs
@@ -186,7 +186,7 @@ impl<'a> Csharp<'a> {
             TableSchemaField::TimeField { name, .. } => {
                 (name.to_string(), String::from("TimeField"))
             }
-            _ => panic!("Unsupported field type {:?}", field),
+            _ => panic!("Unsupported field type {:?}, please report a bug!", field),
         };
         let field_ref = self.variable_name(&field_name);
 

--- a/src/codegen/csharp.rs
+++ b/src/codegen/csharp.rs
@@ -194,7 +194,7 @@ impl<'a> Csharp<'a> {
             | TableSchemaField::ObjectField { .. }
             | TableSchemaField::YearField { .. }
             | TableSchemaField::YearMonthField { .. } => {
-                panic!("Unsupported field type {:?}, please report a bug!", field)
+                unreachable!("Unsupported field type {:?}, please report a bug!", field)
             }
         };
         let field_ref = self.variable_name(&field_name);

--- a/src/codegen/csharp.rs
+++ b/src/codegen/csharp.rs
@@ -186,7 +186,16 @@ impl<'a> Csharp<'a> {
             TableSchemaField::TimeField { name, .. } => {
                 (name.to_string(), String::from("TimeField"))
             }
-            _ => panic!("Unsupported field type {:?}, please report a bug!", field),
+            TableSchemaField::AnyField { .. }
+            | TableSchemaField::ArrayField { .. }
+            | TableSchemaField::DurationField { .. }
+            | TableSchemaField::GeoJsonField { .. }
+            | TableSchemaField::GeoPointField { .. }
+            | TableSchemaField::ObjectField { .. }
+            | TableSchemaField::YearField { .. }
+            | TableSchemaField::YearMonthField { .. } => {
+                panic!("Unsupported field type {:?}, please report a bug!", field)
+            }
         };
         let field_ref = self.variable_name(&field_name);
 

--- a/src/codegen/nodejs.rs
+++ b/src/codegen/nodejs.rs
@@ -252,7 +252,16 @@ impl<'a> NodeJs<'a> {
                 String::from("DateTimeField"),
                 String::from("DateTimeField"),
             ),
-            _ => panic!("Unsupported field type {:?}, please report a bug!", field),
+            TableSchemaField::AnyField { .. }
+            | TableSchemaField::ArrayField { .. }
+            | TableSchemaField::DurationField { .. }
+            | TableSchemaField::GeoJsonField { .. }
+            | TableSchemaField::GeoPointField { .. }
+            | TableSchemaField::ObjectField { .. }
+            | TableSchemaField::YearField { .. }
+            | TableSchemaField::YearMonthField { .. } => {
+                panic!("Unsupported field type {:?}, please report a bug!", field)
+            }
         };
         let field_ref = self.variable_name(&field_name);
 

--- a/src/codegen/nodejs.rs
+++ b/src/codegen/nodejs.rs
@@ -252,7 +252,7 @@ impl<'a> NodeJs<'a> {
                 String::from("DateTimeField"),
                 String::from("DateTimeField"),
             ),
-            _ => panic!("Unsupported field type {:?}", field),
+            _ => panic!("Unsupported field type {:?}, please report a bug!", field),
         };
         let field_ref = self.variable_name(&field_name);
 

--- a/src/codegen/nodejs.rs
+++ b/src/codegen/nodejs.rs
@@ -260,7 +260,7 @@ impl<'a> NodeJs<'a> {
             | TableSchemaField::ObjectField { .. }
             | TableSchemaField::YearField { .. }
             | TableSchemaField::YearMonthField { .. } => {
-                panic!("Unsupported field type {:?}, please report a bug!", field)
+                unreachable!("Unsupported field type {:?}, please report a bug!", field)
             }
         };
         let field_ref = self.variable_name(&field_name);

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -252,7 +252,7 @@ impl<'a> Python<'a> {
             | TableSchemaField::ObjectField { .. }
             | TableSchemaField::YearField { .. }
             | TableSchemaField::YearMonthField { .. } => {
-                panic!("Unsupported field type {:?}, please report a bug!", field)
+                unreachable!("Unsupported field type {:?}, please report a bug!", field)
             }
         };
         let field_ref = self.variable_name(&field_name);

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -244,7 +244,16 @@ impl<'a> Python<'a> {
             TableSchemaField::DateTimeField { name, .. } => {
                 (name.to_string(), String::from("DateTimeField"))
             }
-            _ => panic!("Unsupported field type {:?}, please report a bug!", field),
+            TableSchemaField::AnyField { .. }
+            | TableSchemaField::ArrayField { .. }
+            | TableSchemaField::DurationField { .. }
+            | TableSchemaField::GeoJsonField { .. }
+            | TableSchemaField::GeoPointField { .. }
+            | TableSchemaField::ObjectField { .. }
+            | TableSchemaField::YearField { .. }
+            | TableSchemaField::YearMonthField { .. } => {
+                panic!("Unsupported field type {:?}, please report a bug!", field)
+            }
         };
         let field_ref = self.variable_name(&field_name);
 

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -244,7 +244,7 @@ impl<'a> Python<'a> {
             TableSchemaField::DateTimeField { name, .. } => {
                 (name.to_string(), String::from("DateTimeField"))
             }
-            _ => panic!("Unsupported field type {:?}", field),
+            _ => panic!("Unsupported field type {:?}, please report a bug!", field),
         };
         let field_ref = self.variable_name(&field_name);
 

--- a/src/command/snowflake.rs
+++ b/src/command/snowflake.rs
@@ -319,9 +319,9 @@ fn rows_to_tables(source_id: Uuid, rows: Vec<InformationSchemaColumnsRow>) -> Ve
             })
             .or_insert(Vec::new());
 
-        // Ignore GEOGRAPHY and GEOMETRY columns. They're currently unsupported.
+        // Ignore columns of currently-unsupported data types
         match row.data_type {
-            SnowflakeType::Geography | SnowflakeType::Geometry => {
+            SnowflakeType::Geography | SnowflakeType::Geometry | SnowflakeType::Variant => {
                 eprintln!(
                         "warning: omitting column \"{}\" of unsupported type {:?} from table \"{}\".\"{}\".\"{}\"",
                         row.column_name,
@@ -454,16 +454,7 @@ fn rows_to_tables(source_id: Uuid, rows: Vec<InformationSchemaColumnsRow>) -> Ve
                 title: None,
                 type_: ObjectFieldType::Object,
             },
-            SnowflakeType::Variant => TableSchemaField::AnyField {
-                constraints: Some(base_constraints),
-                description: row.comment.clone(),
-                example: None,
-                name: row.column_name.clone(),
-                rdf_type: None,
-                title: None,
-                type_: AnyFieldType::Any,
-            },
-            SnowflakeType::Geography | SnowflakeType::Geometry => {
+            SnowflakeType::Geography | SnowflakeType::Geometry | SnowflakeType::Variant => {
                 unreachable!("unexpected: {:?}", row.data_type)
             }
         })

--- a/src/command/snowflake.rs
+++ b/src/command/snowflake.rs
@@ -8,9 +8,9 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::descriptor::{
-    AnyFieldType, ArrayFieldType, BooleanFieldType, Constraints, DataResource, DateFieldType,
-    DateTimeFieldType, NumberFieldType, ObjectFieldType, SourcePath, StringFieldFormat,
-    StringFieldType, TableSchema, TableSchemaField, TableSource, TimeFieldType,
+    ArrayFieldType, BooleanFieldType, Constraints, DataResource, DateFieldType, DateTimeFieldType,
+    NumberFieldType, ObjectFieldType, SourcePath, StringFieldFormat, StringFieldType, TableSchema,
+    TableSchemaField, TableSource, TimeFieldType,
 };
 use crate::session;
 use crate::{built_info, command::snowflake::dpm_agent::query::SelectExpression, env};

--- a/src/command/snowflake.rs
+++ b/src/command/snowflake.rs
@@ -8,9 +8,9 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::descriptor::{
-    ArrayFieldType, BooleanFieldType, Constraints, DataResource, DateFieldType, DateTimeFieldType,
-    NumberFieldType, ObjectFieldType, SourcePath, StringFieldFormat, StringFieldType, TableSchema,
-    TableSchemaField, TableSource, TimeFieldType,
+    BooleanFieldType, Constraints, DataResource, DateFieldType, DateTimeFieldType, NumberFieldType,
+    SourcePath, StringFieldFormat, StringFieldType, TableSchema, TableSchemaField, TableSource,
+    TimeFieldType,
 };
 use crate::session;
 use crate::{built_info, command::snowflake::dpm_agent::query::SelectExpression, env};
@@ -321,7 +321,11 @@ fn rows_to_tables(source_id: Uuid, rows: Vec<InformationSchemaColumnsRow>) -> Ve
 
         // Ignore columns of currently-unsupported data types
         match row.data_type {
-            SnowflakeType::Geography | SnowflakeType::Geometry | SnowflakeType::Variant => {
+            SnowflakeType::Array
+            | SnowflakeType::Geography
+            | SnowflakeType::Geometry
+            | SnowflakeType::Object
+            | SnowflakeType::Variant => {
                 eprintln!(
                         "warning: omitting column \"{}\" of unsupported type {:?} from table \"{}\".\"{}\".\"{}\"",
                         row.column_name,
@@ -434,27 +438,11 @@ fn rows_to_tables(source_id: Uuid, rows: Vec<InformationSchemaColumnsRow>) -> Ve
                 title: None,
                 type_: DateTimeFieldType::Datetime,
             },
-            SnowflakeType::Array => TableSchemaField::ArrayField {
-                constraints: Some(base_constraints),
-                description: row.comment.clone(),
-                example: None,
-                format: Default::default(),
-                name: row.column_name.clone(),
-                rdf_type: None,
-                title: None,
-                type_: ArrayFieldType::Array,
-            },
-            SnowflakeType::Object => TableSchemaField::ObjectField {
-                constraints: Some(base_constraints),
-                description: row.comment.clone(),
-                example: None,
-                format: Default::default(),
-                name: row.column_name.clone(),
-                rdf_type: None,
-                title: None,
-                type_: ObjectFieldType::Object,
-            },
-            SnowflakeType::Geography | SnowflakeType::Geometry | SnowflakeType::Variant => {
+            SnowflakeType::Array
+            | SnowflakeType::Geography
+            | SnowflakeType::Geometry
+            | SnowflakeType::Object
+            | SnowflakeType::Variant => {
                 unreachable!("unexpected: {:?}", row.data_type)
             }
         })


### PR DESCRIPTION
- Warn+omit ARRAY, OBJECT, and VARIANT-type columns during `dpm describe snowflake`, as no codegen targets support them.
- Prefer explicit patterns instead of wildcard arm in codegen mappings from universal type -> language type. This will make it harder to unintentionally not cover a pattern in codegen.

PAT-4356 is a specialized version of a broader issue: There exist some Snowflake types that can be `describe`'d but not code-gen'd, not only in some targets but in _any_ targets. After auditing, it turns out the problematic data types are the [semi-structured types](https://docs.snowflake.com/en/sql-reference/data-types-semistructured):
- ARRAY
- OBJECT
- VARIANT

We definitely intend to support these better, but we don't currently and the result when attempting to use them is poor: a panic during `build-package`. This PR fixes that panic by replacing it with a warn+omission from the descriptor during `describe`.

Further possible improvements on this code:
- [PAT-3895](https://linear.app/patch-tech/issue/PAT-3895/finish-simplifying-the-descriptor): Remove variants from [`TableSchemaField`](https://github.com/patch-tech/dpm/blob/1bd20b948e34a0d1aa3fc7340798ebb81e0068e0/src/descriptor/table_schema.rs#L1221-L1598) until the following is true: "If a column can be described, all targets support it". In other words, there are no `unreachable!` branches in the codegens' match expressions.