### PR TITLE
feat(login): If stored token fails basic validation, do flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--staging-database <NAME>` option (default value: `PATCH`) when creating a Snowflake source.
 
 ### Changed
-- Rename `dpm describe` to `dpm init`.
-- Give helpful error message if introspection metadata during `dpm init` is too large.
+- `describe`: Rename `dpm describe` to `dpm init`.
+- `describe`: Give helpful error message if introspection metadata during the command is too large.
+- `login`: If a session.json exists but contains a token failing a basic validity check, initiate the normal login flow.
 
 ### Deprecated
 

--- a/src/command/login.rs
+++ b/src/command/login.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 
 use crate::env;
 use crate::github;
+use crate::session;
 
 /// Ensures that a valid session is stored in the CLI's session.json file.
 ///
@@ -13,19 +14,24 @@ use crate::github;
 pub async fn login() -> Result<()> {
     let session_path = env::session_path()?;
     if session_path.exists() {
-        println!("Session file present at: {}", session_path.display());
-        println!("You are already logged in.");
-        Ok(())
-    } else {
-        let token = github::login().await?;
-        println!();
-
-        let contents = serde_json::to_string_pretty(&token)?;
-        std::fs::write(&session_path, contents)
-            .with_context(|| format!("Error writing session file: {}", session_path.display()))?;
-
-        println!("Session file written to: {}", session_path.display());
-        println!("You are now logged in.");
-        Ok(())
+        let token = session::get_token()?;
+        if github::token_is_valid(&token).await? {
+            println!("Session file present at: {}", session_path.display());
+            println!("You are already logged in.");
+            return Ok(());
+        }
+        // If token exists but doesn't pass cursory validation, proceed with the
+        // login flow as though the invalid session.json weren't present at all.
     }
+
+    let token = github::login().await?;
+    println!();
+
+    let contents = serde_json::to_string_pretty(&token)?;
+    std::fs::write(&session_path, contents)
+        .with_context(|| format!("Error writing session file: {}", session_path.display()))?;
+
+    println!("Session file written to: {}", session_path.display());
+    println!("You are now logged in.");
+    Ok(())
 }


### PR DESCRIPTION
- During `dpm login`, if a session.json exists but its token fails basic validation, continue with normal login flow

This saves the user the trouble of having to `rm` their session.json file in case the token within is no longer valid.

## Test plan

Already having a valid session:
```
% cargo run -- login
   Compiling dpm v0.3.0 (/Users/spencer/code/dpm)
    Finished dev [unoptimized + debuginfo] target(s) in 4.57s
     Running `target/debug/dpm login`
Session file present at: /Users/spencer/Library/Application Support/tech.patch.dpm/session.json
You are already logged in.
```
Having an invalid session:
```
% cargo run -- login
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/dpm login`
Login code has been copied to clipboard. Or, copy it here: 6A1F-0ABE
Enter it at this URL: https://github.com/login/device
...
```
Having no session at all:
```
% cargo run -- login
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/dpm login`
Login code has been copied to clipboard. Or, copy it here: 81CC-5BB1
Enter it at this URL: https://github.com/login/device
```