### PR TITLE
feat(pat-3355): define `inPast` using computed time bounds in nodeJS

### DIFF
--- a/static/nodejs/src/field.ts
+++ b/static/nodejs/src/field.ts
@@ -373,7 +373,7 @@ export function addDuration(
     case 'seconds':
       result.setTime(result.getTime() + n * MILLIS_PER_SECOND);
       break;
-    case 'millis':
+    case 'milliseconds':
       result.setTime(result.getTime() + n);
       break;
   }

--- a/static/nodejs/src/field_expr.ts
+++ b/static/nodejs/src/field_expr.ts
@@ -35,7 +35,7 @@ export type TimeOperator = 'hour' | 'minute' | 'second' | 'millisecond';
 export type ProjectionOperator = DateOperator | TimeOperator;
 
 export type DateGranularity = 'years' | 'months' | 'weeks' | 'days';
-export type TimeGranularity = 'hours' | 'minutes' | 'seconds' | 'millis';
+export type TimeGranularity = 'hours' | 'minutes' | 'seconds' | 'milliseconds';
 export type DateTimeGranularity = DateGranularity | TimeGranularity;
 
 export type Operator =

--- a/static/nodejs/test/field.test.ts
+++ b/static/nodejs/test/field.test.ts
@@ -82,6 +82,10 @@ describe('addDuration', () => {
   expect(addDuration(now, 10, 'minutes').getTime() - now.getTime()).toBe(
     10 * 60 * 1000
   );
+
+  expect(addDuration(now, 123, 'milliseconds').getTime() - now.getTime()).toBe(
+    123
+  );
 });
 
 describe('DateField', () => {
@@ -262,23 +266,29 @@ describe('TimeField', () => {
   test('inPast operator clamps to time bounds', () => {
     const startedAt = new TimeField('startedOn');
     const inPast = startedAt.inPast(0, 25, 'hours');
-    let [operand1, operand2] = inPast.operands() as [BooleanFieldExpr, BooleanFieldExpr];
+    let [operand1, operand2] = inPast.operands() as [
+      BooleanFieldExpr,
+      BooleanFieldExpr
+    ];
 
     let lowerBound = (operand1.operands()[1] as LiteralField<string>)
       .value as string;
     let upperBound = (operand2.operands()[1] as LiteralField<string>)
       .value as string;
-    expect(lowerBound).toBe("00:00:00.000");
+    expect(lowerBound).toBe('00:00:00.000');
     expect(lowerBound <= upperBound).toBe(true);
 
     const inFuture = startedAt.inPast(-24, 0, 'hours');
-    [operand1, operand2] = inFuture.operands() as [BooleanFieldExpr, BooleanFieldExpr];
+    [operand1, operand2] = inFuture.operands() as [
+      BooleanFieldExpr,
+      BooleanFieldExpr
+    ];
 
     lowerBound = (operand1.operands()[1] as LiteralField<string>)
       .value as string;
     upperBound = (operand2.operands()[1] as LiteralField<string>)
       .value as string;
-    expect(upperBound).toBe("23:59:59.999");
+    expect(upperBound).toBe('23:59:59.999');
     expect(lowerBound <= upperBound).toBe(true);
   });
 });

--- a/static/nodejs/test/field.test.ts
+++ b/static/nodejs/test/field.test.ts
@@ -258,6 +258,29 @@ describe('TimeField', () => {
     expect(lowerBound).toMatch(ISO_TIME_REGEX);
     expect(lowerBound <= upperBound).toBe(true);
   });
+
+  test('inPast operator clamps to time bounds', () => {
+    const startedAt = new TimeField('startedOn');
+    const inPast = startedAt.inPast(0, 25, 'hours');
+    let [operand1, operand2] = inPast.operands() as [BooleanFieldExpr, BooleanFieldExpr];
+
+    let lowerBound = (operand1.operands()[1] as LiteralField<string>)
+      .value as string;
+    let upperBound = (operand2.operands()[1] as LiteralField<string>)
+      .value as string;
+    expect(lowerBound).toBe("00:00:00.000");
+    expect(lowerBound <= upperBound).toBe(true);
+
+    const inFuture = startedAt.inPast(-24, 0, 'hours');
+    [operand1, operand2] = inFuture.operands() as [BooleanFieldExpr, BooleanFieldExpr];
+
+    lowerBound = (operand1.operands()[1] as LiteralField<string>)
+      .value as string;
+    upperBound = (operand2.operands()[1] as LiteralField<string>)
+      .value as string;
+    expect(upperBound).toBe("23:59:59.999");
+    expect(lowerBound <= upperBound).toBe(true);
+  });
 });
 
 describe('DateTimeField', () => {


### PR DESCRIPTION
- Defines the `inPast` relative time check as `(lower <= <field> <= upper)`, where `lower, upper` are time bounds computed w.r.t. current time.

### Test plan
- Added unit tests.