### PR TITLE
chore: Add rust-toolchain.toml

### DIFF
--- a/.github/workflows/test-dpm.yml
+++ b/.github/workflows/test-dpm.yml
@@ -125,4 +125,4 @@ jobs:
         run: cargo fmt --all --check
 
       - name: cargo clippy
-        run: cargo clippy -D warnings
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/test-dpm.yml
+++ b/.github/workflows/test-dpm.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
           override: true
 
       - name: Run cargo check
@@ -53,7 +52,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
           override: true
 
       - name: Run cargo test
@@ -134,7 +132,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
           override: true
 
       - name: Run cargo fmt

--- a/.github/workflows/test-dpm.yml
+++ b/.github/workflows/test-dpm.yml
@@ -15,16 +15,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
+      - name: Install Rust
+        run: rustup show
 
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - name: cargo check
+        run: cargo check
 
   test:
     name: Test Suite
@@ -48,14 +43,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
+      - name: Install Rust
+        run: rustup show
 
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
+      - name: cargo test
         env:
           PATCH_AUTH_TOKEN: ${{ secrets.PATCH_AUTH_TOKEN }}
           DPM_AUTH_TOKEN: ${{ secrets.DPM_AUTH_TOKEN }}
@@ -64,8 +55,7 @@ jobs:
           SNOWSQL_PWD: ${{ secrets.SNOWSQL_PWD }}
           SNOWSQL_DATABASE: ${{ secrets.SNOWSQL_DATABASE }}
           SNOWSQL_WAREHOUSE: ${{ secrets.SNOWSQL_SCHEMA }}
-        with:
-          command: test
+        run: cargo test
 
   nodejs-test:
     name: Static TypeScript Test Suite
@@ -128,20 +118,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          override: true
+      - name: Install Rust
+        run: rustup show
 
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: cargo fmt
+        run: cargo fmt --all --check
 
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - name: cargo clippy
+        run: cargo clippy -D warnings

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.73.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.73.0"
+components = ["rustfmt", "clippy"]

--- a/src/command/snowflake.rs
+++ b/src/command/snowflake.rs
@@ -324,7 +324,7 @@ fn rows_to_tables(source_id: Uuid, rows: Vec<InformationSchemaColumnsRow>) -> Ve
                 schema: &row.table_schema,
                 table: &row.table_name,
             })
-            .or_insert(Vec::new());
+            .or_default();
 
         // Ignore columns of currently-unsupported data types
         match row.data_type {


### PR DESCRIPTION
- Add [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file), which `rustup` honors
- Replace uses of unmaintained GitHub Action in workflow with direct `cargo ...` invocations

This does not contradict the `rust-version = "1.69.0"` in Cargo.toml as that denotes the package's _minimum_ supported Rust version.

This may drift from whatever shell.nix pulls in from nixpkgs, but I'm not sure how to pin packages on Nix.