### PR TITLE
feat(publish): Warn if decelerating a package

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -212,21 +212,8 @@ pub struct CreatePackageVersion<'a> {
     pub dataset: &'a Vec<DataResource>,
 }
 
-#[allow(non_snake_case)]
-fn TEMPORARY_default_version() -> Version {
-    Version {
-        major: 0,
-        minor: 1,
-        patch: 0,
-        pre: semver::Prerelease::new("draft.0").unwrap(),
-        build: semver::BuildMetadata::EMPTY,
-    }
-}
-
 #[derive(Deserialize)]
 pub struct PackageVersion {
-    // TODO(PAT-4126): Drop this default
-    #[serde(default = "TEMPORARY_default_version")]
     pub version: Version,
     #[serde(default)]
     pub accelerated: bool,

--- a/src/codegen/csharp.rs
+++ b/src/codegen/csharp.rs
@@ -486,6 +486,7 @@ mod tests {
             package_description: dp.description.unwrap_or("".into()),
             version: PackageVersion {
                 version: dp.version,
+                accelerated: false,
                 dataset: dp.dataset,
             },
         };

--- a/src/codegen/nodejs.rs
+++ b/src/codegen/nodejs.rs
@@ -600,6 +600,7 @@ mod tests {
             package_description: dp.description.unwrap_or("".into()),
             version: PackageVersion {
                 version: dp.version,
+                accelerated: false,
                 dataset: dp.dataset,
             },
         };

--- a/src/codegen/python.rs
+++ b/src/codegen/python.rs
@@ -593,6 +593,7 @@ mod tests {
             package_description: dp.description.unwrap_or("".into()),
             version: PackageVersion {
                 version: dp.version,
+                accelerated: false,
                 dataset: dp.dataset,
             },
         };

--- a/src/command/publish.rs
+++ b/src/command/publish.rs
@@ -40,6 +40,8 @@ pub async fn publish(descriptor_path: &Path) -> Result<()> {
     let token = session::get_token()?;
     let client = api::Client::new(&token)?;
 
+    // Note: The `find` below depends on `client.get_package_versions` returning versions in
+    // reverse version order.
     let response = client.get_package_versions(&package.id.to_string()).await?;
     let latest_release_version = response
         .package_versions

--- a/src/command/publish.rs
+++ b/src/command/publish.rs
@@ -31,7 +31,10 @@ pub async fn publish(descriptor_path: &Path) -> Result<()> {
 
     if !tables_missing_pk.is_empty() {
         let name_list = tables_missing_pk.join(", ");
-        bail!("Cannot publish accelerated package when some tables do not have a primary key defined: {}", name_list)
+        bail!(
+            "Cannot publish package when some tables do not have a primary key defined: {}",
+            name_list
+        )
     }
 
     let token = session::get_token()?;


### PR DESCRIPTION
- Warn user if publishing a version that's not accelerated as the successor to a version that is
- Resolve TODO whose time has come
- Drop misleading word in error message

## Test plan

Output when the scenario triggers:
```
WARNING: Latest release version (0.1.10) is accelerated, but the version about to be published (0.1.11) is not.

How do you want to proceed?:
> Ignore descriptor, publish accelerated
  Respect descriptor, publish unaccelerated
```
I can navigate between the choices with up/down arrow keys, select one with Enter, or abort with Escape:
```
WARNING: Latest release version (0.1.10) is accelerated, but the version about to be published (0.1.11) is not.

Publish cancelled
```