### PR TITLE
feat(source create): Support BigQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - descriptor: Support new `accelerated` field at the top level of the descriptor. If set while running `publish`, the resulting version will be an accelerated version. Accelerated packages have a certain lifecycle, which stderr output will explain.
+- `source create bigquery`: Support creating BigQuery sources
 
 ### Changed
 - `build-package`: Update static code in all targets to redefine the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bitflags"
@@ -522,6 +522,7 @@ name = "dpm"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "base64",
  "built",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ build = "build.rs"
 
 [dependencies]
 anyhow = "1.0.72"
+base64 = "0.21.4"
 chrono = { version = "0.4.26", features = ["serde"] }
 clap = { version = "4.3.0", features = ["derive"] }
 clap_complete = "4.3.1"

--- a/src/api.rs
+++ b/src/api.rs
@@ -37,6 +37,12 @@ pub enum CreateSourceParameters<'a> {
 #[derive(Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum GetSourceParameters {
+    #[serde(rename = "bigquery")]
+    BigQuery {
+        name: String,
+        project_id: String,
+        staging_project_id: String,
+    },
     Snowflake {
         organization: snowflake::OrganizationName,
         account: String,
@@ -195,6 +201,7 @@ pub struct Source {
 impl Source {
     pub fn type_name(&self) -> String {
         match self.source_parameters {
+            GetSourceParameters::BigQuery { .. } => "bigquery".into(),
             GetSourceParameters::Snowflake { .. } => "snowflake".into(),
         }
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -17,6 +17,13 @@ pub enum SnowflakeAuthenticationMethod<'a> {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum CreateSourceParameters<'a> {
+    #[serde(rename = "bigquery")]
+    BigQuery {
+        project_id: &'a str,
+        staging_project_id: &'a str,
+        #[serde(rename = "credentials_key")]
+        credentials_key_b64: String,
+    },
     Snowflake {
         organization: snowflake::OrganizationName,
         account: &'a str,

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -54,6 +54,12 @@ pub async fn init(
     }
 
     let dataset = match source.source_parameters {
+        #[allow(unused_variables)] // TODO(PAT-4696): Remove this allowance
+        api::GetSourceParameters::BigQuery {
+            name,
+            project_id,
+            staging_project_id,
+        } => bail!("init with BigQuery not yet supported"), // TODO(PAT-4696)
         api::GetSourceParameters::Snowflake { .. } => match refinement {
             Some(DescribeRefinement::Snowflake { table, schema }) => {
                 snowflake::describe(source.id, table, schema)

--- a/src/command/source.rs
+++ b/src/command/source.rs
@@ -13,6 +13,8 @@ use super::snowflake;
 
 #[derive(Debug, Subcommand)]
 pub enum CreateSource {
+    /// Create a BigQuery source
+    #[command(name = "bigquery")]
     BigQuery {
         /// Name to give the created source.
         #[arg(long, short)]
@@ -35,6 +37,7 @@ pub enum CreateSource {
         #[arg(long, value_name = "PATH")]
         credentials_key: PathBuf,
     },
+    /// Create a Snowflake source
     Snowflake {
         /// Name to give the created source.
         #[arg(long, short)]


### PR DESCRIPTION
- Support `source create bigquery`

## Test plan

Help output:
```
% cargo run -- source create bigquery --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/dpm source create bigquery --help`
Create a BigQuery source

Usage: dpm source create bigquery --name <NAME> --project-id <PROJECT_ID> --staging-project-id <STAGING_PROJECT_ID> --credentials-key <PATH>

Options:
  -n, --name <NAME>
          Name to give the created source
      --project-id <PROJECT_ID>
          ID of your Google Cloud project
      --staging-project-id <STAGING_PROJECT_ID>
          ID of the Google Cloud project which dpm will use to perform change data capture on tables in this source. This value is only used when there exist accelerated data packages that access data from this source
      --credentials-key <PATH>
          Path to a JSON file containing a GCP service account key. For instructions on how to create such a file, see https://cloud.google.com/iam/docs/keys-create-delete#creating
  -h, --help
          Print help
```

Using:
```
% cargo run -- source create bigquery -n first-bq-source --project-id REDACTED --staging-project-id REDACTED --
...
Source created
```