### PR TITLE
feat(build-package): Forbid building accelerated packages that are still initializing

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -265,6 +265,15 @@ pub enum PatchState {
     ErrorSyncing,
 }
 
+impl PatchState {
+    pub fn has_completed_initial_sync(&self) -> bool {
+        match self {
+            PatchState::SyncingInitial | PatchState::ErrorSyncingInitial => false,
+            PatchState::Syncing | PatchState::ErrorSyncing => true,
+        }
+    }
+}
+
 impl Display for PatchState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {

--- a/src/api.rs
+++ b/src/api.rs
@@ -265,15 +265,6 @@ pub enum PatchState {
     ErrorSyncing,
 }
 
-impl PatchState {
-    pub fn has_completed_initial_sync(&self) -> bool {
-        match self {
-            PatchState::SyncingInitial | PatchState::ErrorSyncingInitial => false,
-            PatchState::Syncing | PatchState::ErrorSyncing => true,
-        }
-    }
-}
-
 impl Display for PatchState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {

--- a/src/command/build_package.rs
+++ b/src/command/build_package.rs
@@ -7,7 +7,7 @@ use anyhow::{bail, Context, Result};
 use semver::Version;
 
 use crate::{
-    api::{Client, CreatePackageVersion, GetPackageVersionResponse},
+    api::{Client, CreatePackageVersion, GetPackageVersionResponse, PatchState},
     codegen::{generate_package, Target},
     descriptor::DataPackage,
     session,
@@ -76,22 +76,44 @@ pub async fn build(
         }
     };
 
-    if build_input.version.accelerated
-        && !build_input
-            .version
-            .patch_state
-            .as_ref()
-            .map_or(false, |s| s.has_completed_initial_sync())
-    {
-        let message =
-            "The package you requested is acceleration-enabled but has not yet completed its initial sync. \
-            To ensure that the expectation of \"If a package version is labeled \'accelerated\', \
-            it's definitely fast to use\" is met, \
-            the building of package instances is forbidden while an accelerated \
-            version is in this temporary state. Please try to build it again once \
-            its initial sync has completed.\n\n\
-            tip: To check the state of the version, use `dpm package list`.";
-        bail!(message)
+    if build_input.version.accelerated {
+        match build_input.version.patch_state.as_ref() {
+            Some(PatchState::SyncingInitial) => {
+                let message = "The package you requested is acceleration-enabled but has not yet completed its initial sync.
+Because it would be potentially confusing for an instance of an \"accelerated\" package
+version to execute its queries without acceleration, the build will abort now.
+Please try to build it again once its initial sync has completed.
+
+tip: To check the state of the version, use `dpm package list`.";
+                bail!(message)
+            }
+            Some(PatchState::ErrorSyncingInitial) => {
+                let error_message = format!(
+                    "Error: {}",
+                    build_input
+                        .version
+                        .patch_state_data
+                        .as_ref()
+                        .unwrap_or(&String::from(
+                            "An unknown error occurred. Please report this issue!"
+                        ))
+                );
+
+                let message = format!("The package you requested to build failed to complete its initial acceleration.
+
+{}
+
+Because it would be potentially confusing for an instance of an \"accelerated\" package
+version to execute its queries without acceleration, the build will abort now.
+Resolve the error above, then try building again.", error_message);
+
+                bail!(message)
+            }
+            Some(PatchState::Syncing) | Some(PatchState::ErrorSyncing) => (
+                // Initial sync has completed => allow build to proceed
+            ),
+            None => bail!("An invalid state has occurred. Please report this issue!"),
+        }
     }
 
     create_dir_all(&out_dir).expect("error creating output directory");

--- a/src/command/build_package.rs
+++ b/src/command/build_package.rs
@@ -76,6 +76,24 @@ pub async fn build(
         }
     };
 
+    if build_input.version.accelerated
+        && !build_input
+            .version
+            .patch_state
+            .as_ref()
+            .map_or(false, |s| s.has_completed_initial_sync())
+    {
+        let message =
+            "The package you requested is acceleration-enabled but has not yet completed its initial sync. \
+            To ensure that the expectation of \"If a package version is labeled \'accelerated\', \
+            it's definitely fast to use\" is met, \
+            the building of package instances is forbidden while an accelerated \
+            version is in this temporary state. Please try to build it again once \
+            its initial sync has completed.\n\n\
+            tip: To check the state of the version, use `dpm package list`.";
+        bail!(message)
+    }
+
     create_dir_all(&out_dir).expect("error creating output directory");
     check_output_dir(&out_dir);
     generate_package(&build_input, &target, &out_dir, assume_yes);


### PR DESCRIPTION
- Forbid building an instance of a package unless it's completed its initial sync

## Test plan

On an accelerated version in state "Error syncing initial":
```
% cargo run -- build-package -p automatically-fast@0.1.6 nodejs
    Finished dev [unoptimized + debuginfo] target(s) in 5.90s
     Running `target/debug/dpm build-package -p 'automatically-fast@0.1.6' nodejs`
package build failed: The package you requested to build failed to complete its initial acceleration.

Error: An unknown error occurred

Because it would be potentially confusing for an instance of an "accelerated" package
version to execute its queries without acceleration, the build will abort now.
Resolve the error above, then try building again.
```

On an accelerated version in state "Syncing":
```
% cargo run -- build-package -p automatically-fast@0.1.9 nodejs
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/dpm build-package -p 'automatically-fast@0.1.9' nodejs`
Going to generate a data-package in NodeJs { scope: None }
Data package already exists at "dist/nodejs/automatically-fast@0.1.9-0.2.2", overwrite? yes
Overwriting
...
```