### PR TITLE
fix(publish): Support publishing w/o creating draft version first

### DIFF
--- a/src/command/build_package.rs
+++ b/src/command/build_package.rs
@@ -35,10 +35,13 @@ pub async fn build(
         let version: Version =
             Version::parse(package_identifier[1]).expect("package identifier `version` is invalid");
 
-        client
+        match client
             .get_package_version(package_identifier[0], version)
-            .await
-            .expect("failed to fetch package")
+            .await?
+        {
+            Some(response) => response,
+            None => bail!("package or package version not found: \"{}\"", package_ref),
+        }
     } else {
         let dp = DataPackage::read(&descriptor)
             .with_context(|| format!("failed to read {}", descriptor.display()))?;

--- a/src/command/publish.rs
+++ b/src/command/publish.rs
@@ -43,10 +43,12 @@ pub async fn publish(descriptor_path: &Path) -> Result<()> {
     // Note: The `find` below depends on `client.get_package_versions` returning versions in
     // reverse version order.
     let response = client.get_package_versions(&package.id.to_string()).await?;
-    let latest_release_version = response
-        .package_versions
-        .iter()
-        .find(|package_version| package_version.version.pre.is_empty());
+    let latest_release_version = response.as_ref().and_then(|response| {
+        response
+            .package_versions
+            .iter()
+            .find(|package_version| package_version.version.pre.is_empty())
+    });
 
     let resolved_accelerated = if let Some(latest_version) = latest_release_version {
         match (latest_version.accelerated, package.accelerated) {


### PR DESCRIPTION
- In GET APIs that can return 404, return `Option` from those to signify the 404 Not Found case
- Handle ^ as warranted in each call site