### PR TITLE
fix(source list): Support listing BigQuery sources

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -41,7 +41,6 @@ pub enum CreateSourceParameters<'a> {
 pub enum GetSourceParameters {
     #[serde(rename = "bigquery")]
     BigQuery {
-        name: String,
         project_id: String,
         staging_project_id: String,
     },

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -56,7 +56,6 @@ pub async fn init(
     let dataset = match source.source_parameters {
         #[allow(unused_variables)] // TODO(PAT-4696): Remove this allowance
         api::GetSourceParameters::BigQuery {
-            name,
             project_id,
             staging_project_id,
         } => bail!("init with BigQuery not yet supported"), // TODO(PAT-4696)


### PR DESCRIPTION
- Remove excess fields from struct type

## Test plan

Before:
```
error listing sources: missing field `name` at line 1 column 8762
```
After:
```
...
  {
    "uuid": "8fe30bbf-6ed4-4823-b656-c273223517e6",
    "name": "first-bq-source",
    "source_parameters": {
      "type": "bigquery",
      "project_id": "<redacted>",
      "staging_project_id": "<redacted>"
    }
  },
...
```