### PR TITLE
fix(pat-4793): overflow and underflow check when adding duration to time

### DIFF
--- a/static/nodejs/src/field.ts
+++ b/static/nodejs/src/field.ts
@@ -662,11 +662,16 @@ export class TimeField extends Field<string> {
       [olderThan, newerThan] = [newerThan, olderThan];
     }
 
-    let now = new Date();
-    let upperBound = addDuration(now, -olderThan, granularity);
+    // We use a Date to perform time arithmetic.
+    // Choose a date that's not the beginning or the end of the month so we
+    // can be certain than an underflow to the previous day or an overflow to
+    // the next day can be checked with a direct comparison of the day part
+    // of the date.
+    let aDay = new Date('2023-10-10T00:00:00.000Z');
+    let upperBound = addDuration(aDay, -olderThan, granularity);
     // Clamp to end of day.
-    if (upperBound.getDate() > now.getDate()) {
-      upperBound = new Date(now);
+    if (upperBound.getDate() > aDay.getDate()) {
+      upperBound = new Date(aDay);
       upperBound.setUTCHours(23);
       upperBound.setUTCMinutes(59);
       upperBound.setUTCSeconds(59);
@@ -674,10 +679,10 @@ export class TimeField extends Field<string> {
     }
     const upperBoundStr = toISOTimeString(upperBound);
 
-    let lowerBound = addDuration(now, -newerThan, granularity);
+    let lowerBound = addDuration(aDay, -newerThan, granularity);
     // Clamp to start of day.
-    if (lowerBound.getDate() < now.getDate()) {
-      lowerBound = new Date(now);
+    if (lowerBound.getDate() < aDay.getDate()) {
+      lowerBound = new Date(aDay);
       lowerBound.setUTCHours(0);
       lowerBound.setUTCMinutes(0);
       lowerBound.setUTCSeconds(0);

--- a/static/nodejs/src/field.ts
+++ b/static/nodejs/src/field.ts
@@ -664,11 +664,11 @@ export class TimeField extends Field<string> {
 
     // We use a Date to perform time arithmetic, and clamp to the ends of the
     // day.
-    let aDay = new Date('2023-10-10T00:00:00.000Z');
-    let upperBound = addDuration(aDay, -olderThan, granularity);
+    let now = new Date();
+    let upperBound = addDuration(now, -olderThan, granularity);
     // Clamp to end of day on overflow.
-    if (toISODateString(upperBound) > toISODateString(aDay)) {
-      upperBound = new Date(aDay);
+    if (toISODateString(upperBound) > toISODateString(now)) {
+      upperBound = new Date(now);
       upperBound.setUTCHours(23);
       upperBound.setUTCMinutes(59);
       upperBound.setUTCSeconds(59);
@@ -676,10 +676,10 @@ export class TimeField extends Field<string> {
     }
     const upperBoundStr = toISOTimeString(upperBound);
 
-    let lowerBound = addDuration(aDay, -newerThan, granularity);
+    let lowerBound = addDuration(now, -newerThan, granularity);
     // Clamp to start of day on underflow.
-    if (toISODateString(lowerBound) < toISODateString(aDay)) {
-      lowerBound = new Date(aDay);
+    if (toISODateString(lowerBound) < toISODateString(now)) {
+      lowerBound = new Date(now);
       lowerBound.setUTCHours(0);
       lowerBound.setUTCMinutes(0);
       lowerBound.setUTCSeconds(0);

--- a/static/nodejs/src/field.ts
+++ b/static/nodejs/src/field.ts
@@ -662,15 +662,12 @@ export class TimeField extends Field<string> {
       [olderThan, newerThan] = [newerThan, olderThan];
     }
 
-    // We use a Date to perform time arithmetic.
-    // Choose a date that's not the beginning or the end of the month so we
-    // can be certain than an underflow to the previous day or an overflow to
-    // the next day can be checked with a direct comparison of the day part
-    // of the date.
+    // We use a Date to perform time arithmetic, and clamp to the ends of the
+    // day.
     let aDay = new Date('2023-10-10T00:00:00.000Z');
     let upperBound = addDuration(aDay, -olderThan, granularity);
-    // Clamp to end of day.
-    if (upperBound.getDate() > aDay.getDate()) {
+    // Clamp to end of day on overflow.
+    if (toISODateString(upperBound) > toISODateString(aDay)) {
       upperBound = new Date(aDay);
       upperBound.setUTCHours(23);
       upperBound.setUTCMinutes(59);
@@ -680,8 +677,8 @@ export class TimeField extends Field<string> {
     const upperBoundStr = toISOTimeString(upperBound);
 
     let lowerBound = addDuration(aDay, -newerThan, granularity);
-    // Clamp to start of day.
-    if (lowerBound.getDate() < aDay.getDate()) {
+    // Clamp to start of day on underflow.
+    if (toISODateString(lowerBound) < toISODateString(aDay)) {
       lowerBound = new Date(aDay);
       lowerBound.setUTCHours(0);
       lowerBound.setUTCMinutes(0);

--- a/static/nodejs/test/field.test.ts
+++ b/static/nodejs/test/field.test.ts
@@ -278,7 +278,7 @@ describe('TimeField', () => {
     expect(lowerBound).toBe('00:00:00.000');
     expect(lowerBound <= upperBound).toBe(true);
 
-    const inFuture = startedAt.inPast(-24, 0, 'hours');
+    const inFuture = startedAt.inPast(-1024, 0, 'hours');
     [operand1, operand2] = inFuture.operands() as [
       BooleanFieldExpr,
       BooleanFieldExpr

--- a/static/python/src/field.py
+++ b/static/python/src/field.py
@@ -258,14 +258,18 @@ def add_duration(d: T, n: int, granularity: DateTimeGranularity) -> T:
     if isinstance(d, time):
         # Adding relativedelta or timedelta to datetime.time is not supported,
         # so use a datetime to perform the arithmetic.
-        today = date.today()
-        dt = datetime.combine(date=today, time=d) + relativedelta.relativedelta(
+        # Choose a date that's not the beginning or the end of the month so we
+        # can be certain than an underflow to the previous day or an overflow to
+        # the next day can be checked with a direct comparison of the day part
+        # of the datetime.
+        a_day = date(2023, 10, 10)
+        dt = datetime.combine(date=a_day, time=d) + relativedelta.relativedelta(
             **kwargs
         )
         # Clamp to 00:00:00.000 and 23:59:59.999
-        if dt.day < today.day:
+        if dt.day < a_day.day:
             return time(hour=0)
-        elif dt.day > today.day:
+        elif dt.day > a_day.day:
             return time(hour=23, minute=59, second=59, microsecond=999999)
         return dt.time()
 

--- a/static/python/src/field.py
+++ b/static/python/src/field.py
@@ -257,19 +257,16 @@ def add_duration(d: T, n: int, granularity: DateTimeGranularity) -> T:
 
     if isinstance(d, time):
         # Adding relativedelta or timedelta to datetime.time is not supported,
-        # so use a datetime to perform the arithmetic.
-        # Choose a date that's not the beginning or the end of the month so we
-        # can be certain than an underflow to the previous day or an overflow to
-        # the next day can be checked with a direct comparison of the day part
-        # of the datetime.
+        # so use a datetime to perform the arithmetic, and clamp to the ends of
+        # the day.
         a_day = date(2023, 10, 10)
         dt = datetime.combine(date=a_day, time=d) + relativedelta.relativedelta(
             **kwargs
         )
         # Clamp to 00:00:00.000 and 23:59:59.999
-        if dt.day < a_day.day:
+        if dt.date() < a_day:
             return time(hour=0)
-        elif dt.day > a_day.day:
+        elif dt.date() > a_day:
             return time(hour=23, minute=59, second=59, microsecond=999999)
         return dt.time()
 

--- a/static/python/src/field.py
+++ b/static/python/src/field.py
@@ -259,14 +259,14 @@ def add_duration(d: T, n: int, granularity: DateTimeGranularity) -> T:
         # Adding relativedelta or timedelta to datetime.time is not supported,
         # so use a datetime to perform the arithmetic, and clamp to the ends of
         # the day.
-        a_day = date(2023, 10, 10)
-        dt = datetime.combine(date=a_day, time=d) + relativedelta.relativedelta(
+        today = date.today()
+        dt = datetime.combine(date=today, time=d) + relativedelta.relativedelta(
             **kwargs
         )
         # Clamp to 00:00:00.000 and 23:59:59.999
-        if dt.date() < a_day:
+        if dt.date() < today:
             return time(hour=0)
-        elif dt.date() > a_day:
+        elif dt.date() > today:
             return time(hour=23, minute=59, second=59, microsecond=999999)
         return dt.time()
 

--- a/static/python/src/test/field_test.py
+++ b/static/python/src/test/field_test.py
@@ -109,10 +109,17 @@ def test_add_duration_returns_expected_results():
     assert add_duration(time(hour=15, minute=2, second=45), -16, "hours") == time(
         hour=0
     )
+    assert add_duration(time(hour=15, minute=2, second=45), -1024, "hours") == time(
+        hour=0
+    )
     # Clamps to last time of day.
     assert add_duration(time(hour=15, minute=2, second=45), 9, "hours") == time(
         hour=23, minute=59, second=59, microsecond=999999
     )
+    assert add_duration(time(hour=15, minute=2, second=45), 9000, "hours") == time(
+        hour=23, minute=59, second=59, microsecond=999999
+    )
+
     assert add_duration(time(hour=15, minute=2, second=45), -12, "minutes") == time(
         hour=14, minute=50, second=45
     )


### PR DESCRIPTION
This change fixes a bug in the underflow and overflow checking logic when adding duration to a time.
The bug's triggered on the beginning or the end of a month because the code
used the current date by default to perform the time arithmetic, and checked if
the result's day of month was before or after the current day of month.
The correct check should compare the entire date (YYYY-MM-DD) value.

NB: No changes are required for C# codegen as that logic uses C#'s in-built wrap output variable that indicates if adding duration to a `TimeOnly` instance underflowed or overflowed.

### Test plan
- Failing unit tests (that ran on 10/31/2023) now pass.
