### PR TITLE
feat(init): Add interactive table/PK selection flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab77dbd8adecaf3f0db40581631b995f312a8a5ae3aa9993188bb8f23d83a5b"
 dependencies = [
- "crossterm",
+ "crossterm 0.26.1",
  "strum",
  "strum_macros",
  "unicode-width",
@@ -450,6 +450,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
 ]
 
 [[package]]
@@ -570,6 +586,7 @@ dependencies = [
  "dialoguer",
  "directories",
  "envy",
+ "inquire",
  "prost",
  "regress",
  "reqwest",
@@ -587,6 +604,12 @@ dependencies = [
  "uuid",
  "uuid7",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "either"
@@ -986,6 +1009,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm 0.25.0",
+ "dyn-clone",
+ "lazy_static",
+ "newline-converter",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1251,15 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "newline-converter"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "nix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ convert_case = "0.6.0"
 copypasta = "0.8.2"
 dialoguer = "0.10.4"
 directories = "5.0.1"
+inquire = "0.6.2"
 prost = "0.11.9"
 regress = "0.6.0"
 reqwest = { version = "0.11.18", default-features = false, features = ["json", "rustls-tls-native-roots"] }

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -139,6 +139,7 @@ fn select_tables_and_keys(
             .with_help_message(
                 "↑↓ to move, enter to select, type to filter, esc to go back to table list, ctrl+c to cancel",
             )
+            // Ensure the user selects at least one field
             .with_validator(inquire::validator::MinLengthValidator::new(1))
             .prompt()
             {

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -136,6 +136,9 @@ fn select_tables_and_keys(
                 "Select the fields that make up the table's primary key",
                 fields.iter().map(|f| f.field_name().to_owned()).collect(),
             )
+            .with_help_message(
+                "↑↓ to move, enter to select, type to filter, esc to go back to table list, ctrl+c to cancel",
+            )
             .with_validator(inquire::validator::MinLengthValidator::new(1))
             .prompt()
             {

--- a/src/command/update.rs
+++ b/src/command/update.rs
@@ -88,13 +88,13 @@ fn print_comparisons(comparisons: &Vec<DatasetComparison>) {
                             }
                             match diff {
                                 FieldComparison::Added { new } => {
-                                    eprintln!("field added: \"{}\"", field_name(new))
+                                    eprintln!("field added: \"{}\"", new.field_name())
                                 }
                                 FieldComparison::Modified { old, .. } => {
-                                    eprintln!("field modified: \"{}\"", field_name(old))
+                                    eprintln!("field modified: \"{}\"", old.field_name())
                                 }
                                 FieldComparison::Removed { old } => {
-                                    eprintln!("field removed: \"{}\"", field_name(old))
+                                    eprintln!("field removed: \"{}\"", old.field_name())
                                 }
                                 FieldComparison::Unchanged { .. } => (/* print nothing */),
                             }
@@ -203,7 +203,7 @@ fn diff_fields<'a>(
         if let Some((idx, &new_f)) = new_fields
             .iter()
             .enumerate()
-            .find(|(_, f)| field_name(f) == field_name(old_f))
+            .find(|(_, f)| f.field_name() == old_f.field_name())
         {
             // Name is the same => either Unchanged or Modified.
             comparisons.push(if new_f == old_f {
@@ -226,32 +226,6 @@ fn diff_fields<'a>(
     }
 
     comparisons
-}
-
-/// Extracts the name of the field.
-///
-/// TODO(PAT-3446): Obviate the need for this.
-/// See also:
-/// - https://stackoverflow.com/questions/49186751/sharing-a-common-value-in-all-enum-values
-/// - https://users.rust-lang.org/t/destructuring-a-common-field-from-many-enum-variants/60997
-fn field_name(f: &TableSchemaField) -> &String {
-    match f {
-        TableSchemaField::StringField { name, .. } => name,
-        TableSchemaField::NumberField { name, .. } => name,
-        TableSchemaField::IntegerField { name, .. } => name,
-        TableSchemaField::DateField { name, .. } => name,
-        TableSchemaField::TimeField { name, .. } => name,
-        TableSchemaField::YearField { name, .. } => name,
-        TableSchemaField::YearMonthField { name, .. } => name,
-        TableSchemaField::BooleanField { name, .. } => name,
-        TableSchemaField::ObjectField { name, .. } => name,
-        TableSchemaField::GeoPointField { name, .. } => name,
-        TableSchemaField::GeoJsonField { name, .. } => name,
-        TableSchemaField::ArrayField { name, .. } => name,
-        TableSchemaField::DurationField { name, .. } => name,
-        TableSchemaField::AnyField { name, .. } => name,
-        TableSchemaField::DateTimeField { name, .. } => name,
-    }
 }
 
 /// The result of comparing one table to another.

--- a/src/descriptor/data_package.rs
+++ b/src/descriptor/data_package.rs
@@ -88,3 +88,12 @@ pub struct DataResource {
     pub source: TableSource,
     pub schema: Option<TableSchema>,
 }
+
+impl DataResource {
+    /// Returns a string that unambiguously identifies a table within a source.
+    pub fn qualified_name(&self) -> String {
+        match &self.source.path {
+            SourcePath::Snowflake { schema, table } => format!("{}.{}", schema, table),
+        }
+    }
+}

--- a/src/descriptor/table_schema.rs
+++ b/src/descriptor/table_schema.rs
@@ -1596,6 +1596,35 @@ pub enum TableSchemaField {
         type_: AnyFieldType,
     },
 }
+
+impl TableSchemaField {
+    /// Extracts the name of the field.
+    ///
+    /// TODO(PAT-3895): Obviate the need for this.
+    /// See also:
+    /// - https://stackoverflow.com/questions/49186751/sharing-a-common-value-in-all-enum-values
+    /// - https://users.rust-lang.org/t/destructuring-a-common-field-from-many-enum-variants/60997
+    pub fn field_name(&self) -> &String {
+        match self {
+            TableSchemaField::StringField { name, .. } => name,
+            TableSchemaField::NumberField { name, .. } => name,
+            TableSchemaField::IntegerField { name, .. } => name,
+            TableSchemaField::DateField { name, .. } => name,
+            TableSchemaField::TimeField { name, .. } => name,
+            TableSchemaField::YearField { name, .. } => name,
+            TableSchemaField::YearMonthField { name, .. } => name,
+            TableSchemaField::BooleanField { name, .. } => name,
+            TableSchemaField::ObjectField { name, .. } => name,
+            TableSchemaField::GeoPointField { name, .. } => name,
+            TableSchemaField::GeoJsonField { name, .. } => name,
+            TableSchemaField::ArrayField { name, .. } => name,
+            TableSchemaField::DurationField { name, .. } => name,
+            TableSchemaField::AnyField { name, .. } => name,
+            TableSchemaField::DateTimeField { name, .. } => name,
+        }
+    }
+}
+
 impl From<&TableSchemaField> for TableSchemaField {
     fn from(value: &TableSchemaField) -> Self {
         value.clone()

--- a/src/env.rs
+++ b/src/env.rs
@@ -52,3 +52,15 @@ pub fn user_agent() -> String {
         None => format!("dpm/{}", built_info::PKG_VERSION),
     }
 }
+
+/// Whether this code is running as part of a CI job.
+fn is_ci() -> bool {
+    // This is always set in GitHub Actions, e.g.
+    // See https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+    std::env::var("CI").map_or(false, |s| s == "true")
+}
+
+/// Whether this code is running during a test run.
+pub fn is_test() -> bool {
+    is_ci() || std::env::var("TEST").map_or(false, |s| s == "true")
+}

--- a/tests/integration_test/nodejs.rs
+++ b/tests/integration_test/nodejs.rs
@@ -10,9 +10,8 @@ impl TargetTester for Nodejs {
         let home_dir = current_dir.as_path();
         exec_cmd(
             &home_dir,
-            "cargo",
+            env!("CARGO_BIN_EXE_dpm"),
             &[
-                "run",
                 "build-package",
                 "-p",
                 package_ref,

--- a/tests/integration_test/python.rs
+++ b/tests/integration_test/python.rs
@@ -12,9 +12,8 @@ impl TargetTester for Python {
         let home_dir = current_dir.as_path();
         exec_cmd(
             &home_dir,
-            "cargo",
+            env!("CARGO_BIN_EXE_dpm"),
             &[
-                "run",
                 "build-package",
                 "-p",
                 package_ref,

--- a/tests/integration_test/target_tester.rs
+++ b/tests/integration_test/target_tester.rs
@@ -119,9 +119,8 @@ pub fn create_snowflake_source(current_dir: &Path) -> String {
 
     exec_cmd(
         current_dir,
-        "cargo",
+        env!("CARGO_BIN_EXE_dpm"),
         &[
-            "run",
             "source",
             "create",
             "snowflake",
@@ -148,9 +147,8 @@ pub fn init_snowflake(current_dir: &PathBuf, source_name: &str) {
 
     exec_cmd(
         &generated_dir,
-        "cargo",
+        env!("CARGO_BIN_EXE_dpm"),
         &[
-            "run",
             "init",
             "-o",
             "datapackage_snowflake.json",
@@ -191,8 +189,8 @@ pub fn publish_snowflake_package(current_dir: &Path) {
 
     exec_cmd(
         &generated_dir,
-        "cargo",
-        &["run", "publish", "-d", "datapackage_snowflake.json"],
+        env!("CARGO_BIN_EXE_dpm"),
+        &["publish", "-d", "datapackage_snowflake.json"],
     );
 }
 


### PR DESCRIPTION
- Add `inquire` dep. We already depend on the similar crate, `dialoguer`, but `inquire` seems a little bit nicer to look at
- Move fn to TableSchemaField.field_name method
- Add interative table/PK specification flow

## Test plan

See demo here: https://asciinema.org/a/8SoLuyfJuUgPpMNBTYwEztDGz