### PR TITLE
fix(package list): Show syncing state as 'Healthy'

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -270,7 +270,7 @@ impl Display for PatchState {
         f.write_str(match self {
             PatchState::SyncingInitial => "Syncing initial",
             PatchState::ErrorSyncingInitial => "Error syncing initial",
-            PatchState::Syncing => "Syncing",
+            PatchState::Syncing => "Healthy",
             PatchState::ErrorSyncing => "Error syncing",
         })
     }


### PR DESCRIPTION
- Present "Syncing" as `Heathy` in `dpm package list` output

To match the terminology in the web app.

@msquinn @whelanBoyd should any other states change, too?