### PR TITLE
feat(source create): Require `dataset` for BigQuery sources

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -22,6 +22,7 @@ pub enum CreateSourceParameters<'a> {
     #[serde(rename = "bigquery")]
     BigQuery {
         project_id: &'a str,
+        dataset: &'a str,
         staging_project_id: &'a str,
         #[serde(rename = "credentials_key")]
         credentials_key_b64: String,
@@ -42,6 +43,7 @@ pub enum GetSourceParameters {
     #[serde(rename = "bigquery")]
     BigQuery {
         project_id: String,
+        dataset: String,
         staging_project_id: String,
     },
     Snowflake {

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -58,6 +58,7 @@ pub async fn init(
         #[allow(unused_variables)] // TODO(PAT-4696): Remove this allowance
         api::GetSourceParameters::BigQuery {
             project_id,
+            dataset,
             staging_project_id,
         } => bail!("init with BigQuery not yet supported"), // TODO(PAT-4696)
         api::GetSourceParameters::Snowflake { .. } => match refinement {

--- a/src/command/source.rs
+++ b/src/command/source.rs
@@ -24,6 +24,9 @@ pub enum CreateSource {
         #[arg(long)]
         project_id: String,
 
+        /// Name of the dataset that will be the data source.
+        dataset: String,
+
         /// ID of the Google Cloud project which dpm will use to perform change
         /// data capture on tables in this source. This value is only used when
         /// there exist accelerated data packages that access data from this
@@ -79,12 +82,11 @@ pub enum SourceAction {
 }
 
 pub async fn create(cs: &CreateSource) -> Result<()> {
-    // create body for POST /sources
-    // submit req
     let input = match cs {
         CreateSource::BigQuery {
             name,
             project_id,
+            dataset,
             staging_project_id,
             credentials_key,
         } => {
@@ -93,6 +95,7 @@ pub async fn create(cs: &CreateSource) -> Result<()> {
                 name,
                 source_parameters: CreateSourceParameters::BigQuery {
                     project_id,
+                    dataset,
                     staging_project_id,
                     credentials_key_b64: b64.encode(credentials_key),
                 },


### PR DESCRIPTION
- Require `dataset` during `dpm source create bigquery`

This ensures that source discovery can occur in a constant number of reqs to BigQuery. In other words: it's fast. If this proves inconvenient—if we get feedback "it's cumbersome to create a new source for every BigQuery dataset!"—then we can look into making `dataset` optional later.