### PR TITLE
style: Fix formatting of output, remove misleading docs

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -31,7 +31,7 @@ enum Command {
         #[arg(short, long, value_name = "PATH", default_value = "datapackage.json")]
         output: PathBuf,
 
-        /// Display name to give the data package that will be created from the
+        /// Name to give the data package that will be created from the
         /// resulting descriptor.
         #[arg(short, long)]
         package_name: Name,

--- a/src/command/publish.rs
+++ b/src/command/publish.rs
@@ -87,12 +87,12 @@ pub async fn publish(descriptor_path: &Path) -> Result<()> {
         package.name, package.version
     );
     if package.accelerated {
-        eprint!(
+        eprintln!(
             "This version is ✨ accelerated. ✨ What this means:
-            - Patch is performing the intial data acceleration now.
-            - Building release packages (`dpm build-package -p <REF>`) is not
-              supported until initial acceleration is complete. To check
-              the status of the acceleration, run `dpm package list`."
+- Patch is performing the intial data acceleration now.
+- Building release packages (`dpm build-package -p <REF>`) is not
+  supported until initial acceleration is complete. To check
+  the status of the acceleration, run `dpm package list`."
         )
     }
 


### PR DESCRIPTION
- Fix formatting of output

The bullet points previously had a bunch of leading whitespace. This gets rid of that.