### PR TITLE
fix(pat-4840): do not install static python package in CI

### DIFF
--- a/.github/workflows/test-dpm.yml
+++ b/.github/workflows/test-dpm.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install dependencies
         working-directory: ./static/python
         run: |
-          poetry install
+          poetry install --no-root
       - name: Run tests
         working-directory: ./static/python
         run: |


### PR DESCRIPTION
Poetry `1.7.0` fails on `poetry install` in the `dpm` Python static dir. Using `package install --no-root` prevents installing the static package and only install dependencies.

### Test plan.
- Upgraded local `poetry` to 1.7.0.
- Running `poetry install` in `dpm/static/python` replicates the failure.
- `poetry install --no-root` runs successfully.