### PR TITLE
feat(api): Add method to consume metadata endpoint

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -107,6 +107,7 @@ impl Client {
         Ok(serde_json::from_str(&body)?)
     }
 
+    #[allow(dead_code)]
     pub async fn get_source_metadata(&self, id: Uuid) -> Result<GetSourceMetadataResponse> {
         let mut url = env::api_base_url()?;
         url.path_segments_mut()

--- a/src/command/update.rs
+++ b/src/command/update.rs
@@ -24,6 +24,7 @@ pub async fn update(base_path: &PathBuf) -> Result<()> {
         .dataset
         .iter()
         .map(|t| match &t.source.path {
+            SourcePath::BigQuery { .. } => todo!("PAT-4574"),
             SourcePath::Snowflake { schema, table } => SnowflakeAllowListItem::Table {
                 schema: Some(schema.to_owned()),
                 table: table.to_owned(),


### PR DESCRIPTION
- `SourcePath`: add method `qualified_name`
- Add method to consume the new `GET /sources/{}/metadata` endpoint

## Test plan

See upstack PR.