### PR TITLE
feat(init): Use metadata endpoint

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -107,7 +107,6 @@ impl Client {
         Ok(serde_json::from_str(&body)?)
     }
 
-    #[allow(dead_code)]
     pub async fn get_source_metadata(&self, id: Uuid) -> Result<GetSourceMetadataResponse> {
         let mut url = env::api_base_url()?;
         url.path_segments_mut()

--- a/src/command/snowflake.rs
+++ b/src/command/snowflake.rs
@@ -126,9 +126,6 @@ fn field_ref_expression(field_name: &str) -> query::Expression {
 }
 
 pub enum SnowflakeAllowListItem {
-    Schema {
-        schema: String,
-    },
     Table {
         schema: Option<String>,
         table: String,
@@ -182,15 +179,8 @@ pub async fn describe(
     let tables = allow_list.map_or(vec![], |items| {
         items
             .iter()
-            .filter_map(|item| match item {
-                SnowflakeAllowListItem::Schema { .. } => None,
-                SnowflakeAllowListItem::Table {
-                    // TODO(PAT-4820): Use schema, otherwise same-named tables
-                    // from distinct schemas could get aliased together and only
-                    // one would be described.
-                    schema: _schema,
-                    table,
-                } => Some(table.to_owned()),
+            .map(|item| match item {
+                SnowflakeAllowListItem::Table { table, .. } => table.to_owned(),
             })
             .collect()
     });
@@ -199,7 +189,6 @@ pub async fn describe(
         items
             .iter()
             .filter_map(|item| match item {
-                SnowflakeAllowListItem::Schema { schema } => Some(schema.to_owned()),
                 SnowflakeAllowListItem::Table { .. } => None,
             })
             .collect()


### PR DESCRIPTION
- During `init`, use the source-type-agnostic metadata endpoint
- Drop now-unused `SnowflakeAllowListItem::Schema` variant

Now the only consumer of `snowflake::describe` is `dpm update`.  That command will be updated, and the dead code deleted, in https://linear.app/patch-tech/issue/PAT-4574/update-dpm-update-for-packages-that-include-bigquery-tables.

## Test plan

Verified creating a datapackage.json for a BigQuery source using
```
cargo run -- init -p new-pkg second-bq-source
```

Also, induced a failure to exercise the error handling:
```
% cargo run -- init -p new-pkg second-bq-source
   Compiling dpm v0.4.0 (/Users/spencer/code/dpm)
    Finished dev [unoptimized + debuginfo] target(s) in 9.60s
     Running `target/debug/dpm init -p new-pkg second-bq-source`
warning: omitting field "name": unrecognized dpm data type "string" (tip: Upgrade `dpm` and try again)
warning: omitting table "microtable1": no fields are usable
init failed: No tables usable in the source. Creating a package with 0 tables is unsupported.
```

Fixes PAT-4696
Fixes PAT-4820