### PR TITLE
fix: Expect string fields to always have `type`

### DIFF
--- a/src/descriptor/data_package.rs
+++ b/src/descriptor/data_package.rs
@@ -206,7 +206,7 @@ impl TryFrom<api::FieldSchema> for TableSchemaField {
                 name: value.name,
                 rdf_type: None,
                 title: None,
-                type_: Some(StringFieldType::String),
+                type_: StringFieldType::String,
             },
             api::DpmBetaType::Boolean => TableSchemaField::BooleanField {
                 constraints: Some(base_constraints),

--- a/src/descriptor/table_schema.rs
+++ b/src/descriptor/table_schema.rs
@@ -1250,8 +1250,8 @@ pub enum TableSchemaField {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         title: Option<String>,
         #[doc = "The type keyword, which `MUST` be a value of `string`."]
-        #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
-        type_: Option<StringFieldType>,
+        #[serde(rename = "type")]
+        type_: StringFieldType,
     },
     NumberField {
         #[doc = "a boolean field with a default of `true`. If `true` the physical contents of this field must follow the formatting constraints already set out. If `false` the contents of this field may contain leading and/or trailing non-numeric characters (which implementors MUST therefore strip). The purpose of `bareNumber` is to allow publishers to publish numeric data that contains trailing characters such as percentages e.g. `95%` or leading characters such as currencies e.g. `€95` or `EUR 95`. Note that it is entirely up to implementors what, if anything, they do with stripped text."]


### PR DESCRIPTION
- Ensure that all field variants require `type` in their serialized form

This has dual benefit:

1. When writing dataset versions to the backend, it ensures that we always _write_ a `type` property on every field
2. When reading dataset versions from the backend, it loudly alerts us to any situation where someone created an invalid dataset, where `type` _wasn't_ defined for some fields

(2) isn't theoretical. An earlier revision of the web app was creating dataset versions w/ invalid data and `dpm build-package` was erroneously appearing to succeed: it built packages and reported success. It was able to deserialize API responses into Rust types because serde was deserializing every field into the `StringField` variant, since every field lacked `type` but the data could still be (and was) deserialized as a `StringField`.