### PR TITLE
feat(update): Identify and report PK differences

### DIFF
--- a/src/command/update.rs
+++ b/src/command/update.rs
@@ -140,7 +140,7 @@ fn print_comparisons(comparisons: &Vec<DatasetComparison>) {
                         eprintln!("table modified: \"{old_name}\" ->");
                         if let Some(pk_diff) = primary_key_diff {
                             eprintln!(
-                                "primary key modified: {} -> {}",
+                                "  primary key modified: {} -> {}",
                                 &pk_diff.old.map_or("none".to_string(), |pk| pk.to_string()),
                                 &pk_diff.new.map_or("none".to_string(), |pk| pk.to_string())
                             );

--- a/src/descriptor/table_schema.rs
+++ b/src/descriptor/table_schema.rs
@@ -10,6 +10,8 @@
 #![allow(clippy::enum_variant_names)]
 #![allow(dead_code)]
 
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 
 #[doc = "The type keyword, which `MUST` be a value of `any`."]
@@ -1653,6 +1655,28 @@ impl From<&TableSchemaObjectPrimaryKey> for TableSchemaObjectPrimaryKey {
 impl From<Vec<String>> for TableSchemaObjectPrimaryKey {
     fn from(value: Vec<String>) -> Self {
         Self::Variant0(value)
+    }
+}
+impl Display for TableSchemaObjectPrimaryKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TableSchemaObjectPrimaryKey::Variant0(fields) => {
+                f.write_str("(")?;
+                let mut iter = fields.iter().peekable();
+
+                while let Some(field) = iter.next() {
+                    f.write_str(field)?;
+                    if iter.peek().is_some() {
+                        f.write_str(", ")?;
+                    }
+                }
+
+                f.write_str(")")
+            }
+            TableSchemaObjectPrimaryKey::Variant1(field) => {
+                f.write_fmt(format_args!("({})", field))
+            }
+        }
     }
 }
 #[doc = "The type keyword, which `MUST` be a value of `time`."]

--- a/src/descriptor/table_schema.rs
+++ b/src/descriptor/table_schema.rs
@@ -1660,19 +1660,7 @@ impl From<Vec<String>> for TableSchemaObjectPrimaryKey {
 impl Display for TableSchemaObjectPrimaryKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TableSchemaObjectPrimaryKey::Variant0(fields) => {
-                f.write_str("(")?;
-                let mut iter = fields.iter().peekable();
-
-                while let Some(field) = iter.next() {
-                    f.write_str(field)?;
-                    if iter.peek().is_some() {
-                        f.write_str(", ")?;
-                    }
-                }
-
-                f.write_str(")")
-            }
+            TableSchemaObjectPrimaryKey::Variant0(fields) => f.write_str(&fields.join(", ")),
             TableSchemaObjectPrimaryKey::Variant1(field) => {
                 f.write_fmt(format_args!("({})", field))
             }


### PR DESCRIPTION
- Report on PK differences between the 'base' dataset version and the 'next' version staged in memory during `dpm update`

When I was working on `dpm update` recently I'd initially overlooked the fact that when the 'next' version is derived from the `GET /sources/{}/metadata` response it will be lacking primary key info, which would cause the diffing during `dpm update` to say "Hey, the base version and the next version are different" (i.e., `!=`). Further, when it came down to precisely telling the user _what_ differed, we wouldn't report anything meaningful. This fixes that 'the output is meaningless' problem.

## Test plan

In main + temporarily commenting out the 'infer the PKs from the base version' here: https://github.com/patch-tech/dpm/blob/4ef6309309ba2f86e33a3376b38b7fe7bb459fec/src/command/update.rs#L41-L70 —`dpm update` yields:
```
% cargo run -- update
table modified: "microtable1" ->
write datapackage.json? no
update cancelled
```

In this branch,
```
% cargo run -- update
table modified: "microtable1" ->
  primary key modified: (name) -> none
write datapackage.json? no
update cancelled
```

I wrote this code to confirm the issue, then wrote the code to infer PKs in the 'next' version from those in the 'base' version. I then verified that the diffs were empty, as desired:

```
% cargo run -- update
no updates to be made
```