### PR TITLE
feat(init): Give helpful post-init message, execute user-facing rename of descriptor -> spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Renamed concepts:
-  - "data package entities" -> "datasets"
-  - "data package instances" -> "data packages"
+  - "data package entity" -> "dataset"
+  - "data package instance" -> "data package"
+  - data package "descriptor" -> "spec"
   - datapackage.json -> dataset.json
-- `init`: Make source name a named argument (`-s`/`--source`). Change name option from `--package-name` to `--dataset`.
+- Update all CLI arguments to reflect the above. As a rule, `--spec` is used for spec inputs, `--dataset` for dataset reference inputs.
+- `init`: Make source name a named argument (`-s`/`--source`). Change name option from `--package-name` to `-n`/`--name`.
 - `build-package`: Update static code in all targets to redefine the
 `inPast` boolean operator in terms of computed relative time bounds.
 - `build-package`: Update `dpm_agent.proto` to include support for table joins. Update generated protobuf code in all targets.

--- a/src/codegen/generator.rs
+++ b/src/codegen/generator.rs
@@ -57,7 +57,7 @@ pub fn exec_cmd(name: &str, path: &Path, cmd: &str, args: &[&str]) {
 
 /// A type that derives the contents of a data package from a `Dataset`.
 pub trait Generator {
-    /// The data package that the generator is processing.
+    /// The dataset that the generator is processing.
     fn dataset(&self) -> &GetDatasetVersionResponse;
 
     /// Returns a dynamic asset that represents a generated table definition

--- a/src/command.rs
+++ b/src/command.rs
@@ -100,7 +100,7 @@ enum Command {
     /// Publish a dataset to Patch
     Publish {
         /// Data package descriptor to read
-        #[arg(short, long, value_name = "FILE", default_value = "dataset.json")]
+        #[arg(long, value_name = "FILE", default_value = "dataset.json")]
         descriptor: PathBuf,
     },
 

--- a/src/command/build_package.rs
+++ b/src/command/build_package.rs
@@ -30,7 +30,7 @@ pub async fn build(
     let build_input: GetDatasetVersionResponse = if let Some(dataset_ref) = dataset_ref {
         let dataset_identifier: Vec<&str> = dataset_ref.split('@').collect();
         if dataset_identifier.len() != 2 {
-            bail!("invalid -d value; expected \"<dataset name>@<version>\"")
+            bail!("invalid --dataset value; expected \"<dataset name>@<version>\"")
         }
         let version: Version =
             Version::parse(dataset_identifier[1]).expect("dataset identifier `version` is invalid");

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -98,7 +98,33 @@ pub async fn init(
         Err(e) => eprintln!("error while writing descriptor: {}", e),
     }
 
+    log_post_init(output);
+
     Ok(())
+}
+
+fn log_post_init(descriptor_path: &Path) {
+    let path = descriptor_path.display();
+
+    eprintln!("
+Next, build a draft data package to validate your dataset:
+
+  $ dpm build-package --descriptor \"{}\" nodejs
+
+Or jump straight to publishing it:
+
+  $ dpm publish --descriptor \"{}\"
+
+Publishing is the first step to making the dataset accessible to others. Once
+published, authorized users may query the dataset via GraphQL, or build data
+packages to query it:
+
+  $ dpm build-package --descriptor \"{}\" nodejs
+  $ dpm build-package --descriptor \"{}\" python
+  $ dpm build-package --descriptor \"{}\" csharp
+
+API docs for the built data packages may be found here: https://docs.dpm.sh/querying-data/data-packages/",
+    path, path, path, path, path);
 }
 
 /// Returns a list of tables that may be used to define a dataset.

--- a/src/command/init.rs
+++ b/src/command/init.rs
@@ -149,7 +149,7 @@ packages to query it:
   $ dpm {} nodejs
   $ dpm {} python
 
-API docs for the built data packages may be found here: https://docs.dpm.sh/querying-data/data-packages/",
+API docs for the built data packages can be found here: https://docs.dpm.sh/querying-data/data-packages/",
         build_draft_package_command, build_draft_package_command, build_draft_package_command,
         publish_dataset_command,
         build_release_package_command, build_release_package_command, build_release_package_command

--- a/src/command/publish.rs
+++ b/src/command/publish.rs
@@ -92,7 +92,7 @@ pub async fn publish(descriptor_path: &Path) -> Result<()> {
 - Patch is performing the intial data acceleration now.
 - Building release packages (`dpm build-package -p <REF>`) is not
   supported until initial acceleration is complete. To check
-  the status of the acceleration, run `dpm package list`."
+  the status of the acceleration, run `dpm dataset list`."
         )
     }
 

--- a/src/command/source.rs
+++ b/src/command/source.rs
@@ -25,6 +25,7 @@ pub enum CreateSource {
         project_id: String,
 
         /// Name of the dataset that will be the data source.
+        #[arg(long, value_name = "NAME")]
         dataset: String,
 
         /// ID of the Google Cloud project which dpm will use to perform change

--- a/src/descriptor/dataset.rs
+++ b/src/descriptor/dataset.rs
@@ -61,6 +61,12 @@ impl Dataset {
             })
             .collect()
     }
+
+    /// Returns the canonical identifier for the dataset/version described by
+    /// `self`.
+    pub fn reference(&self) -> String {
+        format!("{}@{}", self.name, self.version)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/tests/integration_test/target_tester.rs
+++ b/tests/integration_test/target_tester.rs
@@ -200,7 +200,7 @@ pub fn publish_snowflake_package(current_dir: &Path) {
     exec_cmd(
         &generated_dir,
         env!("CARGO_BIN_EXE_dpm"),
-        &["publish", "-d", "datapackage_snowflake.json"],
+        &["publish", "-s", "datapackage_snowflake.json"],
     );
 }
 


### PR DESCRIPTION
- Give helpful message when `dpm init` completes
- In docs, rename "descriptor" references to "spec"
- Convert BigQuery's positional `dataset` argument to a named arg `--dataset <NAME>`

## Test plan

Creating a default-named spec (dataset.json),
```
% dpm init -s second-bq-source -n pk-diff-test-fresh
> Select a table to add to dataset: microtable1
> Select the fields that make up the table's primary key name
wrote descriptor: dataset.json

Next, build a draft data package to validate your dataset:

  $ dpm build-package csharp
  $ dpm build-package nodejs
  $ dpm build-package python

Or jump straight to publishing it:

  $ dpm publish

Publishing is the first step to making the dataset accessible to others. Once
published, authorized users may query the dataset via GraphQL, or build data
packages to query it:

  $ dpm build-package -d "pk-diff-test-fresh@0.1.0" csharp
  $ dpm build-package -d "pk-diff-test-fresh@0.1.0" nodejs
  $ dpm build-package -d "pk-diff-test-fresh@0.1.0" python

API docs for the built data packages may be found here: https://docs.dpm.sh/querying-data/data-packages/
```

Or using a custom spec path:
```
% dpm init -s second-bq-source -n pk-diff-test-fresh -o cool_spec.json
> Select a table to add to dataset: microtable1
> Select the fields that make up the table's primary key name
wrote descriptor: cool_spec.json

Next, build a draft data package to validate your dataset:

  $ dpm build-package -s "cool_spec.json" csharp
  $ dpm build-package -s "cool_spec.json" nodejs
  $ dpm build-package -s "cool_spec.json" python

Or jump straight to publishing it:

  $ dpm publish -s "cool_spec.json"

Publishing is the first step to making the dataset accessible to others. Once
published, authorized users may query the dataset via GraphQL, or build data
packages to query it:

  $ dpm build-package -d "pk-diff-test-fresh@0.1.0" csharp
  $ dpm build-package -d "pk-diff-test-fresh@0.1.0" nodejs
  $ dpm build-package -d "pk-diff-test-fresh@0.1.0" python

API docs for the built data packages may be found here: https://docs.dpm.sh/querying-data/data-packages/
```