### PR TITLE
feat(source create snowflake): Support format `--account {org}.{account}`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,9 +1505,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "regress"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a9ecfa0cb04d0b04dddb99b8ccf4f66bc8dfd23df694b398570bd8ae3a50fb"
+checksum = "4ed9969cad8051328011596bf549629f1b800cf1731e7964b1eef8dfc480d2c2"
 dependencies = [
  "hashbrown 0.13.2",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ dialoguer = "0.10.4"
 directories = "5.0.1"
 inquire = "0.6.2"
 prost = "0.11.9"
-regress = "0.6.0"
+regress = "0.7.1"
 reqwest = { version = "0.11.18", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 rust-embed = { version = "6.6.1", features = ["include-exclude"] }
 semver = { version = "1.0.18", features = ["serde"] }

--- a/src/command/snowflake.rs
+++ b/src/command/snowflake.rs
@@ -22,7 +22,12 @@ impl std::str::FromStr for OrganizationName {
     }
 }
 
-pub fn derive_account_identifiers<'a>(
+/// If `account_name` is of the form '{org}.{account}', prefer that. Otherwise,
+/// rely on both org and account name having been provided separately. If
+/// neither work out, return `Err`.
+///
+/// See also: https://docs.snowflake.com/en/user-guide/admin-account-identifier
+pub fn resolve_account_identifiers<'a>(
     organization_name: Option<&'a OrganizationName>,
     account_name: &'a str,
 ) -> Result<(OrganizationName, &'a str)> {

--- a/src/command/snowflake.rs
+++ b/src/command/snowflake.rs
@@ -1,21 +1,48 @@
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 
+// Source: https://docs.snowflake.com/en/user-guide/admin-account-identifier#organization-name
+// We assume that when ^ refers to "letters" that means [a-zA-Z].
+const ORG_NAME_PATTERN: &str = "[a-zA-Z][a-zA-Z0-9]*";
+const ACCOUNT_NAME_PATTERN: &str = "[a-zA-Z]\\w*";
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OrganizationName(String);
 impl std::str::FromStr for OrganizationName {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Source: https://docs.snowflake.com/en/user-guide/admin-account-identifier#organization-name
-        // We assume that when ^ refers to "letters" that means [a-zA-Z].
-        if regress::Regex::new("^[a-zA-Z][a-zA-Z0-9]*$")
-            .unwrap()
-            .find(s)
-            .is_none()
-        {
-            bail!("doesn't match pattern \"^[a-zA-Z][a-zA-Z0-9]*$\"");
+        let pattern = format!("^{}$", ORG_NAME_PATTERN);
+
+        if regress::Regex::new(&pattern).unwrap().find(s).is_none() {
+            bail!("doesn't match pattern \"{}\"", pattern);
         }
-        Ok(Self(s.to_string()))
+
+        Ok(Self(s.to_owned()))
     }
+}
+
+pub fn derive_account_identifiers<'a>(
+    organization_name: Option<&'a OrganizationName>,
+    account_name: &'a str,
+) -> Result<(OrganizationName, &'a str)> {
+    let combined_pattern = regress::Regex::new(&format!(
+        "^(?<org_name>{})[.-](?<account_name>{})$",
+        ORG_NAME_PATTERN, ACCOUNT_NAME_PATTERN
+    ))
+    .unwrap();
+
+    if let Some(result) = combined_pattern.find(account_name) {
+        // SAFETY: Regex match implies that both groups matched.
+        let org_name = &account_name[result.named_group("org_name").unwrap()];
+        let account_name = &account_name[result.named_group("account_name").unwrap()];
+
+        return Ok((OrganizationName(org_name.to_owned()), account_name));
+    }
+
+    if let Some(org_name) = organization_name {
+        return Ok((org_name.to_owned(), account_name));
+    }
+
+    bail!("Invalid account identifers given. Provide account identifiers either via `--account ${{ORG_NAME}}.${{ACCOUNT_NAME}}`, or via `--organization ${{ORG_NAME}} --account ${{ACCOUNT_NAME}}`.")
 }

--- a/src/command/source.rs
+++ b/src/command/source.rs
@@ -114,7 +114,7 @@ pub async fn create(cs: &CreateSource) -> Result<()> {
             staging_database,
         } => {
             let (organization, account) =
-                snowflake::derive_account_identifiers(organization.as_ref(), account)?;
+                snowflake::resolve_account_identifiers(organization.as_ref(), account)?;
 
             CreateSourceInput {
                 name,


### PR DESCRIPTION
- Upgrade regress dep
- Support more user-friendly `--account {org}.{account}` format when creating Snowflake sources

## Test plan

Failure:
```
% cargo run -- source create snowflake -n testing-easier-identifier --account ASDF --user redacted --password redacted --database redacted
error creating source: Invalid account identifers given. Provide account identifiers either via `--account ${ORG_NAME}.${ACCOUNT_NAME}, or via `--organization ${ORG_NAME} --account ${ACCOUNT_NAME}`.
```

Success:

```
% cargo run -- source create snowflake -n testing-easier-identifier --account ABC123.DEF456 --user redacted --password redacted --database redacted
Source created
```
&& verifying the expected values were persisted:
```
dpm=> select source_parameters->'organization', source_parameters->'account' from source where name = 'testing-easier-identifier';
 ?column?  | ?column?
-----------+-----------
 "ABC123" | "DEF456"
(1 row)
```