### PR TITLE
fix(pat-5034): include order-by expressions when computing the group-by clause

### DIFF
--- a/static/nodejs/src/backends/dpm_agent/dpm_agent_client.ts
+++ b/static/nodejs/src/backends/dpm_agent/dpm_agent_client.ts
@@ -254,12 +254,12 @@ export function makeDpmAgentQuery(query: Table): DpmAgentQuery {
   }
 
   // Process any groupings defined in selection or orderBy.
-  const selectionMap = new Set<FieldExpr>(selection ?? []);
+  const selectionSet = new Set<string>((selection ?? []).map((x) => x.name));
   const expandedSelection = [
     ...(selection ?? []),
     ...(orderBy ?? [])
       .map((x: Ordering) => x[0])
-      .filter((x) => !selectionMap.has(x)),
+      .filter((x) => !selectionSet.has(x.name)),
   ];
   if (
     expandedSelection.findIndex(

--- a/static/nodejs/test/dpm_query_builder.test.ts
+++ b/static/nodejs/test/dpm_query_builder.test.ts
@@ -195,9 +195,9 @@ describe('makeDpmAgentQuery', () => {
 
   test('returns expected Query message for a query with selections, filter, aggregations', () => {
     const query = table
-      .select('id', 'name', price.avg().as('avgPrice'))
+      .select('id', createdOn.day, price.avg().as('avgPrice'))
       .filter(name.like('%bah%').and(createdOn.before(new Date('2023-01-01'))))
-      .orderBy(['avgPrice', 'DESC'], [name, 'ASC'], [createdOn, 'ASC']) // Note that createdOn is not in the selection.
+      .orderBy(['avgPrice', 'DESC'], [createdOn.day, 'ASC'], [name, 'ASC']) // Note that `name` is not in the selection.
       .limit(10);
     const dpmQuery = makeDpmAgentQuery(query);
     const want: DpmAgentQuery.AsObject = {
@@ -223,9 +223,14 @@ describe('makeDpmAgentQuery', () => {
         },
         {
           argument: {
-            field: {
-              fieldname: 'name',
-              tablename: '',
+            derived: {
+              op: DpmAgentQuery.DerivedExpression.ProjectionOperator.DAY,
+              argument: {
+                field: {
+                  fieldname: 'created_on',
+                  tablename: '',
+                },
+              },
             },
           },
           alias: '',
@@ -313,14 +318,19 @@ describe('makeDpmAgentQuery', () => {
           },
         },
         {
-          field: {
-            fieldname: 'name',
-            tablename: '',
+          derived: {
+            op: DpmAgentQuery.DerivedExpression.ProjectionOperator.DAY,
+            argument: {
+              field: {
+                fieldname: 'created_on',
+                tablename: '',
+              },
+            },
           },
         },
         {
           field: {
-            fieldname: 'created_on',
+            fieldname: 'name',
             tablename: '',
           },
         },
@@ -342,9 +352,14 @@ describe('makeDpmAgentQuery', () => {
         },
         {
           argument: {
-            field: {
-              fieldname: 'name',
-              tablename: '',
+            derived: {
+              op: DpmAgentQuery.DerivedExpression.ProjectionOperator.DAY,
+              argument: {
+                field: {
+                  fieldname: 'created_on',
+                  tablename: '',
+                },
+              },
             },
           },
           direction: DpmAgentQuery.OrderByExpression.Direction.ASC,
@@ -352,7 +367,7 @@ describe('makeDpmAgentQuery', () => {
         {
           argument: {
             field: {
-              fieldname: 'created_on',
+              fieldname: 'name',
               tablename: '',
             },
           },

--- a/static/nodejs/test/dpm_query_builder.test.ts
+++ b/static/nodejs/test/dpm_query_builder.test.ts
@@ -197,7 +197,7 @@ describe('makeDpmAgentQuery', () => {
     const query = table
       .select('id', 'name', price.avg().as('avgPrice'))
       .filter(name.like('%bah%').and(createdOn.before(new Date('2023-01-01'))))
-      .orderBy(['avgPrice', 'DESC'], [createdOn, 'ASC']) // Note that createdOn is not in the seletion.
+      .orderBy(['avgPrice', 'DESC'], [name, 'ASC'], [createdOn, 'ASC']) // Note that createdOn is not in the selection.
       .limit(10);
     const dpmQuery = makeDpmAgentQuery(query);
     const want: DpmAgentQuery.AsObject = {
@@ -339,6 +339,15 @@ describe('makeDpmAgentQuery', () => {
             },
           },
           direction: DpmAgentQuery.OrderByExpression.Direction.DESC,
+        },
+        {
+          argument: {
+            field: {
+              fieldname: 'name',
+              tablename: '',
+            },
+          },
+          direction: DpmAgentQuery.OrderByExpression.Direction.ASC,
         },
         {
           argument: {

--- a/static/nodejs/test/dpm_query_builder.test.ts
+++ b/static/nodejs/test/dpm_query_builder.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, test } from '@jest/globals';
+import { makeDpmAgentQuery } from '../src/backends/dpm_agent/dpm_agent_client';
+import {
+  ClientVersion,
+  Query as DpmAgentQuery,
+} from '../src/backends/dpm_agent/dpm_agent_pb';
+import { Backend } from '../src/backends/interface';
+import { DateField, Field, StringField } from '../src/field';
+import { Table } from '../src/table';
+
+class TestBackend implements Backend {
+  compile(_query: Table): Promise<string> {
+    return Promise.resolve('SELECT * from "foo"');
+  }
+
+  execute<Row extends object>(_query: Table): Promise<Row[]> {
+    let res: Row[] = [];
+    return Promise.resolve(res);
+  }
+}
+
+describe('makeDpmAgentQuery', () => {
+  const backend = new TestBackend();
+
+  const id = new StringField('id');
+  const name = new StringField('name');
+  const price = new Field<number>('price');
+  const createdOn = new DateField('created_on');
+  const table = new Table({
+    backend,
+    packageId: 'pkg-123',
+    datasetName: 'ds-456',
+    datasetVersion: '0.1.0',
+    source: 'test',
+    name: 'testTable',
+    fields: [id, name, price, createdOn],
+  });
+
+  test('returns expected Query message for a query with selections only', () => {
+    const query = table.select('id', 'name').limit(10);
+    const dpmQuery = makeDpmAgentQuery(query);
+    const want: DpmAgentQuery.AsObject = {
+      id: {
+        packageid: 'pkg-123',
+        sourceid: '',
+      },
+      clientversion: {
+        client: ClientVersion.Client.NODE_JS,
+        datasetversion: '0.1.0',
+        codeversion: '0.1.0',
+      },
+      selectfrom: 'testTable',
+      selectList: [
+        {
+          argument: {
+            field: {
+              fieldname: 'id',
+              tablename: '',
+            },
+          },
+          alias: '',
+        },
+        {
+          argument: {
+            field: {
+              fieldname: 'name',
+              tablename: '',
+            },
+          },
+          alias: '',
+        },
+      ],
+      limit: 10,
+      // Default values.
+      dryrun: false,
+      tablealias: '',
+      type: DpmAgentQuery.Type.DATA,
+      groupbyList: [],
+      orderbyList: [],
+      joinsList: [],
+    };
+
+    expect(dpmQuery.toObject(false)).toEqual(want);
+  });
+
+  test('returns expected Query message for a query with selections, and filter', () => {
+    const query = table
+      .select('id', 'name')
+      .filter(name.like('%bah%').and(createdOn.before(new Date('2023-01-01'))))
+      .limit(10);
+    const dpmQuery = makeDpmAgentQuery(query);
+    const want: DpmAgentQuery.AsObject = {
+      id: {
+        packageid: 'pkg-123',
+        sourceid: '',
+      },
+      clientversion: {
+        client: ClientVersion.Client.NODE_JS,
+        datasetversion: '0.1.0',
+        codeversion: '0.1.0',
+      },
+      selectfrom: 'testTable',
+      selectList: [
+        {
+          argument: {
+            field: {
+              fieldname: 'id',
+              tablename: '',
+            },
+          },
+          alias: '',
+        },
+        {
+          argument: {
+            field: {
+              fieldname: 'name',
+              tablename: '',
+            },
+          },
+          alias: '',
+        },
+      ],
+      filter: {
+        op: DpmAgentQuery.BooleanExpression.BooleanOperator.AND,
+        argumentsList: [
+          {
+            condition: {
+              op: DpmAgentQuery.BooleanExpression.BooleanOperator.LIKE,
+              argumentsList: [
+                {
+                  field: {
+                    fieldname: 'name',
+                    tablename: '',
+                  },
+                },
+                {
+                  literal: {
+                    string: '%bah%',
+                    // Unfortunately, the <message>.AsObject type does not
+                    // handle oneof fields as expected; all non-object type
+                    // fields are required to be defined.
+                    f32: 0,
+                    f64: 0,
+                    i32: 0,
+                    i64: 0,
+                    pb_boolean: false,
+                    timestamp: 0,
+                    ui32: 0,
+                    ui64: 0,
+                  },
+                },
+              ],
+            },
+          },
+          {
+            condition: {
+              op: DpmAgentQuery.BooleanExpression.BooleanOperator.LT,
+              argumentsList: [
+                {
+                  field: {
+                    fieldname: 'created_on',
+                    tablename: '',
+                  },
+                },
+                {
+                  literal: {
+                    string: '2023-01-01',
+                    f32: 0,
+                    f64: 0,
+                    i32: 0,
+                    i64: 0,
+                    pb_boolean: false,
+                    timestamp: 0,
+                    ui32: 0,
+                    ui64: 0,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      limit: 10,
+      // Default values.
+      dryrun: false,
+      tablealias: '',
+      type: DpmAgentQuery.Type.DATA,
+      groupbyList: [],
+      orderbyList: [],
+      joinsList: [],
+    };
+
+    expect(dpmQuery.toObject(false)).toEqual(want);
+  });
+
+  test('returns expected Query message for a query with selections, filter, aggregations', () => {
+    const query = table
+      .select('id', 'name', price.avg().as('avgPrice'))
+      .filter(name.like('%bah%').and(createdOn.before(new Date('2023-01-01'))))
+      .orderBy(['avgPrice', 'DESC'], [createdOn, 'ASC']) // Note that createdOn is not in the seletion.
+      .limit(10);
+    const dpmQuery = makeDpmAgentQuery(query);
+    const want: DpmAgentQuery.AsObject = {
+      id: {
+        packageid: 'pkg-123',
+        sourceid: '',
+      },
+      clientversion: {
+        client: ClientVersion.Client.NODE_JS,
+        datasetversion: '0.1.0',
+        codeversion: '0.1.0',
+      },
+      selectfrom: 'testTable',
+      selectList: [
+        {
+          argument: {
+            field: {
+              fieldname: 'id',
+              tablename: '',
+            },
+          },
+          alias: '',
+        },
+        {
+          argument: {
+            field: {
+              fieldname: 'name',
+              tablename: '',
+            },
+          },
+          alias: '',
+        },
+        {
+          argument: {
+            aggregate: {
+              op: DpmAgentQuery.AggregateExpression.AggregateOperator.MEAN,
+              argument: {
+                field: {
+                  fieldname: 'price',
+                  tablename: '',
+                },
+              },
+            },
+          },
+          alias: 'avgPrice',
+        },
+      ],
+      filter: {
+        op: DpmAgentQuery.BooleanExpression.BooleanOperator.AND,
+        argumentsList: [
+          {
+            condition: {
+              op: DpmAgentQuery.BooleanExpression.BooleanOperator.LIKE,
+              argumentsList: [
+                {
+                  field: {
+                    fieldname: 'name',
+                    tablename: '',
+                  },
+                },
+                {
+                  literal: {
+                    string: '%bah%',
+                    // Unfortunately, the <message>.AsObject type does not
+                    // handle oneof fields as expected; all non-object type
+                    // fields are required to be defined.
+                    f32: 0,
+                    f64: 0,
+                    i32: 0,
+                    i64: 0,
+                    pb_boolean: false,
+                    timestamp: 0,
+                    ui32: 0,
+                    ui64: 0,
+                  },
+                },
+              ],
+            },
+          },
+          {
+            condition: {
+              op: DpmAgentQuery.BooleanExpression.BooleanOperator.LT,
+              argumentsList: [
+                {
+                  field: {
+                    fieldname: 'created_on',
+                    tablename: '',
+                  },
+                },
+                {
+                  literal: {
+                    string: '2023-01-01',
+                    f32: 0,
+                    f64: 0,
+                    i32: 0,
+                    i64: 0,
+                    pb_boolean: false,
+                    timestamp: 0,
+                    ui32: 0,
+                    ui64: 0,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      groupbyList: [
+        {
+          field: {
+            fieldname: 'id',
+            tablename: '',
+          },
+        },
+        {
+          field: {
+            fieldname: 'name',
+            tablename: '',
+          },
+        },
+        {
+          field: {
+            fieldname: 'created_on',
+            tablename: '',
+          },
+        },
+      ],
+      orderbyList: [
+        {
+          argument: {
+            aggregate: {
+              op: DpmAgentQuery.AggregateExpression.AggregateOperator.MEAN,
+              argument: {
+                field: {
+                  fieldname: 'price',
+                  tablename: '',
+                },
+              },
+            },
+          },
+          direction: DpmAgentQuery.OrderByExpression.Direction.DESC,
+        },
+        {
+          argument: {
+            field: {
+              fieldname: 'created_on',
+              tablename: '',
+            },
+          },
+          direction: DpmAgentQuery.OrderByExpression.Direction.ASC,
+        },
+      ],
+      limit: 10,
+      // Default values.
+      dryrun: false,
+      tablealias: '',
+      type: DpmAgentQuery.Type.DATA,
+      joinsList: [],
+    };
+
+    expect(dpmQuery.toObject(false)).toEqual(want);
+  });
+});

--- a/static/nodejs/test/field_expr.test.ts
+++ b/static/nodejs/test/field_expr.test.ts
@@ -1,69 +1,73 @@
-import { FieldExpr, BooleanFieldExpr, UnaryBooleanFieldExpr, Operator, Expr } from '../src/field_expr';
+import {
+  AggregateFieldExpr,
+  FieldExpr,
+  BooleanFieldExpr,
+  UnaryBooleanFieldExpr,
+  Operator,
+  Expr,
+} from '../src/field_expr';
 import { describe, expect, test } from '@jest/globals';
-import { AggregateFieldExpr } from '../src/field_expr';
 
 class ConcreteFieldExpr extends FieldExpr {
-    operator(): Operator {
-        return 'ident';
-    }
+  operator(): Operator {
+    return 'ident';
+  }
 
-    operands(): Expr[] {
-        return [];
-    }
+  operands(): Expr[] {
+    return [];
+  }
 }
 
 describe('FieldExpr', () => {
-    test('should have correct name property', () => {
-        const field = new ConcreteFieldExpr('field');
+  test('should have correct name property', () => {
+    const field = new ConcreteFieldExpr('field');
 
-        expect(field.name).toBe('field');
-    });
+    expect(field.name).toBe('field');
+  });
 });
 
 describe('BooleanFieldExpr', () => {
-    test('should have correct field, op, and other properties', () => {
-        const field = new ConcreteFieldExpr('field');
-        const other = new ConcreteFieldExpr('other');
-        const booleanFieldExpr = new BooleanFieldExpr(field, 'eq', other);
+  test('should have correct field, op, and other properties', () => {
+    const field = new ConcreteFieldExpr('field');
+    const other = new ConcreteFieldExpr('other');
+    const booleanFieldExpr = new BooleanFieldExpr(field, 'eq', other);
 
-        expect(booleanFieldExpr.field).toBe(field);
-        expect(booleanFieldExpr.op).toBe('eq');
-        expect(booleanFieldExpr.other).toBe(other);
-    });
+    expect(booleanFieldExpr.field).toBe(field);
+    expect(booleanFieldExpr.op).toBe('eq');
+    expect(booleanFieldExpr.other).toBe(other);
+  });
 
-    test('should return correct operator', () => {
-        const field = new ConcreteFieldExpr('field');
-        const other = new ConcreteFieldExpr('other');
-        const booleanFieldExpr = new BooleanFieldExpr(field, 'eq', other);
+  test('should return correct operator', () => {
+    const field = new ConcreteFieldExpr('field');
+    const other = new ConcreteFieldExpr('other');
+    const booleanFieldExpr = new BooleanFieldExpr(field, 'eq', other);
 
-        expect(booleanFieldExpr.operator()).toBe('eq');
-    });
-
+    expect(booleanFieldExpr.operator()).toBe('eq');
+  });
 });
 
 describe('UnaryBooleanFieldExpr', () => {
-    test('should have correct field and op properties', () => {
-        const field = new ConcreteFieldExpr('field');
-        const unaryBooleanFieldExpr = new UnaryBooleanFieldExpr(field, 'isNull');
+  test('should have correct field and op properties', () => {
+    const field = new ConcreteFieldExpr('field');
+    const unaryBooleanFieldExpr = new UnaryBooleanFieldExpr(field, 'isNull');
 
-        expect(unaryBooleanFieldExpr.field).toBe(field);
-        expect(unaryBooleanFieldExpr.op).toBe('isNull');
-    });
+    expect(unaryBooleanFieldExpr.field).toBe(field);
+    expect(unaryBooleanFieldExpr.op).toBe('isNull');
+  });
 
-    test('should return correct operator', () => {
-        const field = new ConcreteFieldExpr('field');
-        const unaryBooleanFieldExpr = new UnaryBooleanFieldExpr(field, 'isNull');
+  test('should return correct operator', () => {
+    const field = new ConcreteFieldExpr('field');
+    const unaryBooleanFieldExpr = new UnaryBooleanFieldExpr(field, 'isNull');
 
-        expect(unaryBooleanFieldExpr.operator()).toBe('isNull');
-    });
-
+    expect(unaryBooleanFieldExpr.operator()).toBe('isNull');
+  });
 });
 
 describe('AggregateFieldExpr', () => {
-    test('should have correct field and op properties', () => {
-        const field = new ConcreteFieldExpr('field');
-        const aggregateFieldExpr = new AggregateFieldExpr<number>(field, 'max');
+  test('should have correct field and op properties', () => {
+    const field = new ConcreteFieldExpr('field');
+    const aggregateFieldExpr = new AggregateFieldExpr<number>(field, 'max');
 
-        expect(aggregateFieldExpr.operator()).toBe('max');
-    });
+    expect(aggregateFieldExpr.operator()).toBe('max');
+  });
 });


### PR DESCRIPTION
- Include all order-by expressions that are not present in the
	selection set when computing the group-by clause.

### Test plan
- Added unit tests.
