### PR TITLE
fix(pat-5034): c# - include order-by when computing group-by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- `build-package`: When computing the group-by clause, include any order-by
+expressions that are not present in the selection set.
 
 ### Security
 

--- a/static/csharp/DpmTest/TestQueryFormulation.cs
+++ b/static/csharp/DpmTest/TestQueryFormulation.cs
@@ -56,15 +56,16 @@ namespace DpmTest
                     startedAt.DayOfWeek.As("Start DOW")
                     )
                 .Filter(name.Like("%ammy%") | price > 10.0f | tags.HasAny(new string[] { "foo", "bar" }))
-                .OrderBy((price.Max(), Direction.DESC))
+                // The OrderBy includes a field expression that's not in the Select.
+                .OrderBy((price.Max(), Direction.DESC), (startedAt.Week, Direction.ASC))
                 .Limit(10);
             var dpmQuery = DpmAgentQueryFactory.MakeQuery(query);
             var wantQueryStr =
                 "{ \"id\": { \"packageId\": \"1124-111\" }, \"selectFrom\": \"my_table\", " +
                 "\"select\": [ { \"argument\": { \"field\": { \"fieldName\": \"name\" } }, " +
                 "\"alias\": \"Name\" }, { \"argument\": { \"aggregate\": { \"op\": \"MAX\", " +
-                "\"argument\": { \"field\": { \"fieldName\": \"price\" } } } }, \"alias\": \"Max price\" }, " +
-                "{ \"argument\": { \"derived\": { \"op\": \"MONTH\", \"argument\": { " +
+                "\"argument\": { \"field\": { \"fieldName\": \"price\" } } } }, \"alias\": \"Max " +
+                "price\" }, { \"argument\": { \"derived\": { \"op\": \"MONTH\", \"argument\": { " +
                 "\"field\": { \"fieldName\": \"startedAt\" } } } }, \"alias\": \"Start month\" " +
                 "}, { \"argument\": { \"derived\": { \"op\": \"DAY_OF_WEEK\", \"argument\": { " +
                 "\"field\": { \"fieldName\": \"startedAt\" } } } }, \"alias\": \"Start DOW\" } " +
@@ -79,11 +80,14 @@ namespace DpmTest
                 "[ { \"field\": { \"fieldName\": \"name\" } }, { \"derived\": { \"op\": " +
                 "\"MONTH\", \"argument\": { \"field\": { \"fieldName\": \"startedAt\" } } } }, { " +
                 "\"derived\": { \"op\": \"DAY_OF_WEEK\", \"argument\": { \"field\": { " +
-                "\"fieldName\": \"startedAt\" } } } } ], \"orderBy\": [ { \"argument\": { " +
-                "\"aggregate\": { \"op\": \"MAX\", \"argument\": { \"field\": { \"fieldName\": " +
-                "\"price\" } } } }, \"direction\": \"DESC\" } ], \"limit\": \"10\", " +
-                "\"clientVersion\": { \"client\": \"CSHARP\", \"datasetVersion\": \"0.1.0\", " +
-                "\"codeVersion\": \"0.1.0\" } }";
+                "\"fieldName\": \"startedAt\" } } } }, { \"derived\": { \"op\": \"WEEK\", " +
+                "\"argument\": { \"field\": { \"fieldName\": \"startedAt\" } } } } ], " +
+                "\"orderBy\": [ { \"argument\": { \"aggregate\": { \"op\": \"MAX\", " +
+                "\"argument\": { \"field\": { \"fieldName\": \"price\" } } } }, \"direction\": " +
+                "\"DESC\" }, { \"argument\": { \"derived\": { \"op\": \"WEEK\", \"argument\": { " +
+                "\"field\": { \"fieldName\": \"startedAt\" } } } }, \"direction\": \"ASC\" } ], " +
+                "\"limit\": \"10\", \"clientVersion\": { \"client\": \"CSHARP\", " +
+                "\"datasetVersion\": \"0.1.0\", \"codeVersion\": \"0.1.0\" } }";
             Assert.AreEqual(wantQueryStr, dpmQuery.ToString());
         }
     }


### PR DESCRIPTION
- Include order-by expressions when computing group-by clause.

### Test plan
- Added unit tests.
